### PR TITLE
Refactor DataTex to use SessionManager Singleton and fix memory leaks

### DIFF
--- a/DataTex.pro
+++ b/DataTex.pro
@@ -31,10 +31,12 @@ CONFIG += c++11
 
 SOURCES += \
         main.cpp \
-        datatex.cpp
+        datatex.cpp \
+        sessionmanager.cpp
 
 HEADERS += \
-        datatex.h
+        datatex.h \
+        sessionmanager.h
 
 FORMS += \
         datatex.ui

--- a/datatex.cpp
+++ b/datatex.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "datatex.h"
 #include "QtAwesome.h"
 #include "ui_datatex.h"
@@ -43,44 +44,8 @@
 
 // QSqlDatabase DataTex::Bibliography_Settings = QSqlDatabase::addDatabase("QSQLITE","BibSettings");
 //QSqlDatabase DataTex::CTANPackages = QSqlDatabase::addDatabase("QSQLITE","CTANPackages");
-//QHash<QString,QSqlDatabase> DataTex::GlobalDatabaseList;
+//QHash<QString,QSqlDatabase> SessionManager::instance().GlobalDatabaseList;
 fa::QtAwesome* awesome = new fa::QtAwesome(qApp);
-
-QHash<QString,DTXDatabase> DataTex::GlobalDatabaseList;
-DTXDatabase DataTex::CurrentFilesDataBase;
-DTXDatabase DataTex::CurrentDocumentsDataBase;
-DTXDatabase DataTex::CurrentBibliographyDataBase;
-DTXDatabase DataTex::CurrentTablesDataBase;
-DTXDatabase DataTex::CurrentFiguresDataBase;
-DTXDatabase DataTex::CurrentCommandsDataBase;
-DTXDatabase DataTex::CurrentPreamblesDataBase;
-DTXDatabase DataTex::CurrentPackagesDataBase;
-DTXDatabase DataTex::CurrentClassesDataBase;
-DTXDatabase DataTex::CurrentDTXDataBase;
-QString DataTex::CurrentPreamble;
-QString DataTex::CurrentPreamble_Content;
-QString DataTex::PdfLatex_Command;
-QString DataTex::Latex_Command;
-QString DataTex::XeLatex_Command;
-QString DataTex::LuaLatex_Command;
-QString DataTex::Pythontex_Command;
-QString DataTex::Bibtex_Command;
-QString DataTex::Asymptote_Command;
-QString DataTex::RunCommand;
-QString DataTex::TexLivePath;
-QString DataTex::GlobalSaveLocation;
-QHash<QString,QString> DataTex::BuildCommands;
-QHash<int,DTXBuildCommand> DataTex::DTXBuildCommands;
-//QHash<QString,QStringList> DataTex::Optional_Metadata_Ids;
-//QHash<QString,QStringList> DataTex::Optional_Metadata_Names;
-QHash<QString,QStringList> DataTex::Optional_DocMetadata_Ids;
-QHash<QString,QStringList> DataTex::Optional_DocMetadata_Names;
-QStringList DataTex::DocTypesIds;
-QStringList DataTex::DocTypesNames;
-QTranslator DataTex::translator;
-QString DataTex::currentlanguage;
-QString DataTex::datatexpath;
-QStringList DataTex::SVG_IconPaths;
 
 // QChartView * DTXDashBoard::ShowPieChart(QWidget *parent,QList<QStringList> info)
 // {
@@ -115,11 +80,13 @@ DataTex::DataTex(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::DataTex)
 {
+    filesTagLine = nullptr;
+    docsTagLine = nullptr;
     QDirIterator symbolIterator(":/images/MathSymbols/" , QStringList() << "*", QDir::Files,QDirIterator::Subdirectories);
     while (symbolIterator.hasNext()){
-        SVG_IconPaths.append(symbolIterator.next());
+        SessionManager::instance().SVG_IconPaths.append(symbolIterator.next());
     }
-    SVG_IconPaths.sort();
+    SessionManager::instance().SVG_IconPaths.sort();
     ui->setupUi(this);
 //    ui->menubar->setHidden(true);
     ui->statusbar->addWidget(ui->statusbarWidget);
@@ -267,21 +234,21 @@ DataTex::DataTex(QWidget *parent)
 
     //Load language------
     readSettings();
-    if (!DataTex::translator.isEmpty()){
-        QCoreApplication::removeTranslator(&DataTex::translator);
+    if (!SessionManager::instance().translator.isEmpty()){
+        QCoreApplication::removeTranslator(&SessionManager::instance().translator);
     }
-    if(!currentlanguage.isEmpty() && !currentlanguage.isNull() && QFile::exists(":/languages/DataTex_"+currentlanguage+".qm")){
-        DataTex::translator.load(":/languages/DataTex_"+currentlanguage+".qm");
+    if(!SessionManager::instance().currentlanguage.isEmpty() && !SessionManager::instance().currentlanguage.isNull() && QFile::exists(":/languages/DataTex_"+SessionManager::instance().currentlanguage+".qm")){
+        SessionManager::instance().translator.load(":/languages/DataTex_"+SessionManager::instance().currentlanguage+".qm");
     }
     else if(QFile::exists(":/languages/DataTex_"+QLocale::system().name()+".qm")){
-        DataTex::translator.load(":/languages/DataTex_"+QLocale::system().name()+".qm");
+        SessionManager::instance().translator.load(":/languages/DataTex_"+QLocale::system().name()+".qm");
     }
-    QCoreApplication::installTranslator(&DataTex::translator);
+    QCoreApplication::installTranslator(&SessionManager::instance().translator);
     //----------------------
 
     //------Load databases, check encryption and add them to the treewidget
-    GlobalDatabaseList.clear();
-    QDirIterator list(datatexpath+"Databases/",QStringList() << "*.json", QDir::Files,QDirIterator::Subdirectories);
+    SessionManager::instance().GlobalDatabaseList.clear();
+    QDirIterator list(SessionManager::instance().datatexpath+"Databases/",QStringList() << "*.json", QDir::Files,QDirIterator::Subdirectories);
     while (list.hasNext()){
         QString dbJsonPath = list.next();
         // qDebug()<<dbJsonPath;
@@ -306,7 +273,7 @@ DataTex::DataTex(QWidget *parent)
         bool isDBmissing = false;
         if(!QFileInfo::exists(path)){
             isDBmissing = true;
-            QFile file(datatexpath+QFileInfo(path).fileName());
+            QFile file(SessionManager::instance().datatexpath+QFileInfo(path).fileName());
             QDir dir(QFileInfo(path).absolutePath());
             if (!dir.exists()){
                 dir.mkpath(".");
@@ -354,7 +321,7 @@ DataTex::DataTex(QWidget *parent)
             }
         }
         DTXDB.Database = database;
-        GlobalDatabaseList.insert(DTXDB.BaseName,DTXDB);
+        SessionManager::instance().GlobalDatabaseList.insert(DTXDB.BaseName,DTXDB);
         AddDatabaseToTree(DTXDB);
         //        isDBEncrypted.insert(DTXDB.BaseName,DTXDB.Encrypt);
         if(isDBmissing){
@@ -362,7 +329,7 @@ DataTex::DataTex(QWidget *parent)
         }
     }
     connect(this,&DataTex::sendDBConnectionInfo,this,[&](int DBConnected){
-        int total = GlobalDatabaseList.count();
+        int total = SessionManager::instance().GlobalDatabaseList.count();
         ConnectAllDatabase->setEnabled(DBConnected<total);
         DisconnectAllDatabase->setEnabled(DBConnected>0);
     });
@@ -375,17 +342,17 @@ DataTex::DataTex(QWidget *parent)
     QString filesdb = settings.value("CurrentFilesDB").toString();
     QString docsdb = settings.value("CurrentDocsDB").toString();
     settings.endGroup();
-    CurrentFilesDataBase = GlobalDatabaseList.value(filesdb);
-    CurrentDocumentsDataBase = GlobalDatabaseList.value(docsdb);
-    CurrentDTXDataBase = CurrentFilesDataBase;
-    DatabaseStructure(CurrentFilesDataBase.Path);// Show database folder structure in tree view
+    SessionManager::instance().CurrentFilesDataBase = SessionManager::instance().GlobalDatabaseList.value(filesdb);
+    SessionManager::instance().CurrentDocumentsDataBase = SessionManager::instance().GlobalDatabaseList.value(docsdb);
+    SessionManager::instance().CurrentDTXDataBase = SessionManager::instance().CurrentFilesDataBase;
+    DatabaseStructure(SessionManager::instance().CurrentFilesDataBase.Path);// Show database folder structure in tree view
     //---------------------------------------------
 
     //Load Database metadata from entries
-    Database_FileTableFields = CurrentFilesDataBase.getIdsList();
-    Database_FileTableFieldNames = CurrentFilesDataBase.getNamesList();
-    Database_DocTableFieldNames = CurrentDocumentsDataBase.getIdsList();
-    Database_DocumentTableColumns = CurrentDocumentsDataBase.getNamesList();
+    Database_FileTableFields = SessionManager::instance().CurrentFilesDataBase.getIdsList();
+    Database_FileTableFieldNames = SessionManager::instance().CurrentFilesDataBase.getNamesList();
+    Database_DocTableFieldNames = SessionManager::instance().CurrentDocumentsDataBase.getIdsList();
+    Database_DocumentTableColumns = SessionManager::instance().CurrentDocumentsDataBase.getNamesList();
     // BibliographyTableColumns = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Bibliography_Fields ORDER BY ROWID",DataTex::Bibliography_Settings);
     // BibliographyFieldIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Bibliography_Fields ORDER BY ROWID",DataTex::Bibliography_Settings);
     //-----------------------------------
@@ -468,16 +435,15 @@ DataTex::DataTex(QWidget *parent)
 
     //Global save location path----
     QString path = dtxSettings.saveLocation;
-    GlobalSaveLocation = (!path.isEmpty()) ? path : QDir::homePath();
+    SessionManager::instance().GlobalSaveLocation = (!path.isEmpty()) ? path : QDir::homePath();
     //-----------------------------
     CloseDatabasefile->setEnabled(false);
 
     //Get Texlive path-----------
-    QProcess *process = new QProcess;
-    process->start("which",QStringList()<<"tlmgr");
-    process->waitForBytesWritten();
-    process->waitForFinished(-1);
-    TexLivePath = QString(process->readAllStandardOutput()).remove("tlmgr\n");
+    QProcess process;
+    process.start("which",QStringList()<<"tlmgr");
+    process.waitForFinished(-1);
+    SessionManager::instance().TexLivePath = QString(process.readAllStandardOutput()).remove("tlmgr\n");
     //---------------------------
 
     ui->SaveDocBibContent->setEnabled(false);
@@ -495,7 +461,7 @@ DataTex::DataTex(QWidget *parent)
         ContentStream << BibContent;
         file.close();
         ui->SaveDocBibContent->setEnabled(false);
-        QSqlQuery needsUpdate(CurrentDocumentsDataBase.Database);
+        QSqlQuery needsUpdate(SessionManager::instance().CurrentDocumentsDataBase.Database);
         needsUpdate.exec(QString("UPDATE Documents SET Bibliography = \"%1\" WHERE Id = \"%2\"").arg(BibContent,DocumentFileName));
     });
 
@@ -511,7 +477,7 @@ DataTex::DataTex(QWidget *parent)
 
     ui->BibEntriesTable->setColumnCount(3);
     ui->BibEntriesTable->setHorizontalHeaderLabels({tr("Citation key"),tr("Document type"),tr("Title")});
-    StretchColumnsToWidth(ui->BibEntriesTable);
+    SessionManager::instance().StretchColumnsToWidth(ui->BibEntriesTable);
     connect(ui->ShowBibSourceFile,&QPushButton::clicked,this,[&](){
         ui->stackedWidget_4->setCurrentIndex(0);
         ui->BibSourceCodeLabel->setText("Source code of file : "+DatabaseFileName);
@@ -522,7 +488,7 @@ DataTex::DataTex(QWidget *parent)
     });
     connect(ui->SaveSourceCode,&QPushButton::clicked,this,[&](){
         QString sourceCode = ui->BibSourceCode->toPlainText();
-        QSqlQuery write(CurrentFilesDataBase.Database);
+        QSqlQuery write(SessionManager::instance().CurrentFilesDataBase.Database);
         write.exec(QString("UPDATE Database_Files SET Bibliography = \""+sourceCode+"\" WHERE Id = '"+DatabaseFileName+"'"));
     });
     ui->BibPerFileTree->setColumnCount(3);
@@ -576,9 +542,9 @@ DataTex::DataTex(QWidget *parent)
     RightClick = new RightClickMenu(this,FilesTable,3);
 
     connect(ui->stackedWidget,&QStackedWidget::currentChanged,this,[&](int index){LoadCountCombo(index);});
-    StretchColumnsToWidth(ui->CountFilesTable);
+    SessionManager::instance().StretchColumnsToWidth(ui->CountFilesTable);
     connect(ui->ComboCount,&QComboBox::currentTextChanged,this,[=](QString text){
-        LoadTableHeaders(ui->CountFilesTable,{text,tr("Number")});
+        SessionManager::instance().LoadTableHeaders(ui->CountFilesTable,{text,tr("Number")});
     });
     connect(ui->DocDepContentPreview,&QPushButton::clicked,this,[&](){ui->stackedWidget_7->setCurrentIndex(0);});
     connect(ui->DocDepPdfPreview,&QPushButton::clicked,this,[&](){ui->stackedWidget_7->setCurrentIndex(1);});
@@ -593,7 +559,7 @@ DataTex::DataTex(QWidget *parent)
     });
     connect(FilesTable,&ExtendedTableWidget::filesfound,this,[=](int files){
         // qDebug()<<"filecount=0"<<files;
-        ui->CurrentBaseLabel->setText(CurrentFilesDataBase.Description+" : "+QString::number(files)+tr(" files"));
+        ui->CurrentBaseLabel->setText(SessionManager::instance().CurrentFilesDataBase.Description+" : "+QString::number(files)+tr(" files"));
     });
     connect(ui->ShowDescription,&QPushButton::toggled,this,[=](bool checked){
         ui->splitter_3->setSizes(QList<int>({(100-20*checked)*height(),20*checked*height()}));
@@ -621,19 +587,19 @@ void DataTex::CreateMenus_Actions()
     OpenDatabasefile = CreateNewAction(FileMenu,OpenDatabasefile,SLOT(OpenLoadDatabase()),"Ctrl+O",QIcon::fromTheme("DatabaseOpen"),tr("&Open a database"));
     CloseDatabasefile = CreateNewAction(FileMenu,CloseDatabasefile,SLOT(RemoveCurrentDatabase()),"Ctrl+E",QIcon::fromTheme("EditDelete"),tr("&Close current database"));
     SyncDatabasefile = CreateNewAction(FileMenu,SyncDatabasefile,SLOT(DatabaseSyncFiles()),"Ctrl+S",QIcon::fromTheme("UpdateDocument"),tr("&Sync files to database"));
-    SaveAsDatabasefile = CreateNewAction(FileMenu,SaveAsDatabasefile,[=](){/*SelectNewFileInModel(FilesTable);*/},"Ctrl+Shift+S",QIcon::fromTheme("DocumentSave"),tr("&Save As..."));
+    SaveAsDatabasefile = CreateNewAction(FileMenu,SaveAsDatabasefile,[=](){/*SessionManager::instance().SelectNewFileInModel(FilesTable);*/},"Ctrl+Shift+S",QIcon::fromTheme("DocumentSave"),tr("&Save As..."));
     ImportDatabaseFrom = CreateNewAction(FileMenu,ImportDatabaseFrom,[](){},"",QIcon::fromTheme("DatabaseImport"),tr("&Import"));
     ExportDatabaseTo = CreateNewAction(FileMenu,ExportDatabaseTo,[](){},"",QIcon::fromTheme("DatabaseExport"),tr("&Export"));
     EncryptDB = CreateNewAction(FileMenu,EncryptDB,[=](){
-            EncryptDatabase * enc = new EncryptDatabase(this,CurrentDTXDataBase);
+            EncryptDatabase * enc = new EncryptDatabase(this,SessionManager::instance().CurrentDTXDataBase);
             connect(enc,&EncryptDatabase::DBEncrypted,this,[&](QString DBId){
                 QTreeWidgetItem * item = ui->OpenDatabasesTreeWidget->findItems(DBId,Qt::MatchExactly | Qt::MatchRecursive,2).at(0);
                 item->setIcon(0,QIcon::fromTheme("Locked"));
-                GlobalDatabaseList[DBId].Database.close();
-                GlobalDatabaseList[DBId].IsConnected = false;
+                SessionManager::instance().GlobalDatabaseList[DBId].Database.close();
+                SessionManager::instance().GlobalDatabaseList[DBId].IsConnected = false;
                 ui->OpenDatabasesTreeWidget->setCurrentItem(item);
                 on_OpenDatabasesTreeWidget_itemClicked(item,0);
-                GlobalDatabaseList[DBId].Encrypt = true;
+                SessionManager::instance().GlobalDatabaseList[DBId].Encrypt = true;
             });
             enc->show();
             enc->activateWindow();
@@ -649,7 +615,7 @@ void DataTex::CreateMenus_Actions()
             AreAllDBConnected();
         },"",QIcon::fromTheme("DisconnectDB"),tr("Disconnect selected database"));
     ConnectAllDatabase = CreateNewAction(FileMenu,ConnectAllDatabase,[=](){
-        for (auto DTXDB = GlobalDatabaseList.cbegin(), end = GlobalDatabaseList.cend(); DTXDB != end; DTXDB++){
+        for (auto DTXDB = SessionManager::instance().GlobalDatabaseList.cbegin(), end = SessionManager::instance().GlobalDatabaseList.cend(); DTXDB != end; DTXDB++){
                 if(!DTXDB->IsConnected){
                     QTreeWidgetItem * item = ui->OpenDatabasesTreeWidget->findItems(DTXDB->BaseName,Qt::MatchExactly | Qt::MatchRecursive,2).at(0);
                     SetDatabaseConnected(item);
@@ -657,7 +623,7 @@ void DataTex::CreateMenus_Actions()
             }
         },"",QIcon::fromTheme("ConnectAllDB"),tr("Connect all databases"));
     DisconnectAllDatabase = CreateNewAction(FileMenu,DisconnectAllDatabase,[=](){
-        for (auto DTXDB = GlobalDatabaseList.cbegin(), end = GlobalDatabaseList.cend(); DTXDB != end; DTXDB++){
+        for (auto DTXDB = SessionManager::instance().GlobalDatabaseList.cbegin(), end = SessionManager::instance().GlobalDatabaseList.cend(); DTXDB != end; DTXDB++){
             if(DTXDB->IsConnected){
                     QTreeWidgetItem * item = ui->OpenDatabasesTreeWidget->findItems(DTXDB->BaseName,Qt::MatchExactly | Qt::MatchRecursive,2).at(0);
                     SetDatabaseDisconnected(item);
@@ -939,7 +905,7 @@ void DataTex::CreateBuildCommands()
             CompileToPdf();
             FileCommands::ClearOldFiles(DatabaseFilePath);
             FileCommands::ShowPdfInViewer(DatabaseFilePath,PdfFileView);
-        QSqlQuery UpdateBuildCommand(CurrentFilesDataBase.Database);
+        QSqlQuery UpdateBuildCommand(SessionManager::instance().CurrentFilesDataBase.Database);
         UpdateBuildCommand.exec(QString("UPDATE Database_Files SET BuildCommand = \"PdfLaTeX\" WHERE Id = \"%1\"").arg(DatabaseFileName));
         UpdateBuildCommand.exec(QString("UPDATE Database_Files SET Preamble = \"%2\" WHERE Id = \"%1\"").arg(DatabaseFileName,FilesPreambleCombo->currentData().toString()));
 //        ShowDataBaseFiles();
@@ -996,8 +962,8 @@ void DataTex::CreateBuildCommands()
 
 void DataTex::loadDatabaseFields()
 {
-    int currentVisibleBasicFieldCount = CurrentFilesDataBase.basicVisibleFieldIndexes().count();
-    int currentCustomFieldCount = CurrentFilesDataBase.customFieldIds().count();
+    int currentVisibleBasicFieldCount = SessionManager::instance().CurrentFilesDataBase.basicVisibleFieldIndexes().count();
+    int currentCustomFieldCount = SessionManager::instance().CurrentFilesDataBase.customFieldIds().count();
     int previousBasicFieldCount = valuelabelList.count();
     int previousCustomFieldCount = editList.count();
     // qDebug()<<currentVisibleBasicFieldCount<<currentCustomFieldCount;
@@ -1077,7 +1043,7 @@ void DataTex::loadDatabaseFields()
 
 
     int i=0;
-    for(DTXDBFieldInfo info : CurrentDTXDataBase.DBFieldInfoList){
+    for(DTXDBFieldInfo info : SessionManager::instance().CurrentDTXDataBase.DBFieldInfoList){
         if(info.isVisibleInTable){
             labelList[i]->setText(info.Name);
             i++;
@@ -1087,9 +1053,9 @@ void DataTex::loadDatabaseFields()
         }
     }
 
-    DocTypesIds.clear();
-    DocTypesNames.clear();
-    DocTypesIds.append({"@article" ,"@book" ,"@mvbook", "@inbook","@bookinbook ","@suppbook",
+    SessionManager::instance().DocTypesIds.clear();
+    SessionManager::instance().DocTypesNames.clear();
+    SessionManager::instance().DocTypesIds.append({"@article" ,"@book" ,"@mvbook", "@inbook","@bookinbook ","@suppbook",
                                "@booklet ","@collection ","@mvcollection",
                                "@incollection ","@suppcollection ","@manual",
                                "@misc ","@online ","@patent",
@@ -1098,7 +1064,7 @@ void DataTex::loadDatabaseFields()
                                "@mvreference ","@inreference ","@report",
                                "@thesis ","@unpublished"});
 
-    DocTypesNames.append({tr("Article") ,tr("Book") ,tr("Multivolume book"), tr("Part of a book"),tr("Book in book") ,tr("Supplemental Material in a book"),
+    SessionManager::instance().DocTypesNames.append({tr("Article") ,tr("Book") ,tr("Multivolume book"), tr("Part of a book"),tr("Book in book") ,tr("Supplemental Material in a book"),
                                tr("Booklet") ,tr("Collection") ,tr("Multivolume collection"),
                                tr("Part in a collection") ,tr("Supplemental material in a collection") ,tr("Manual"),
                                tr("Miscellaneous") ,tr("Online resource") ,tr("Patent"),
@@ -1109,8 +1075,8 @@ void DataTex::loadDatabaseFields()
     // QSqlQuery CustomDocTypes(Bibliography_Settings);
     // CustomDocTypes.exec("SELECT Id,Name FROM DocumentTypes WHERE Basic = '0'");
     // while (CustomDocTypes.next()) {
-    //     DocTypesIds.append(CustomDocTypes.value(0).toString());
-    //     DocTypesNames.append(CustomDocTypes.value(1).toString());
+    //     SessionManager::instance().DocTypesIds.append(CustomDocTypes.value(0).toString());
+    //     SessionManager::instance().DocTypesNames.append(CustomDocTypes.value(1).toString());
     // }
 }
 
@@ -1133,12 +1099,12 @@ void DataTex::SettingsDatabase_Variables()
     //         <<tr("Path")<<tr("Date")<<tr("Content")<<"Preamble"
     //        <<tr("LaTeX build command")<<tr("Needs update")<<tr("Bibliography")<<tr("Description")<<tr("Solution document");
 
-    datatexpath = QDir::homePath()+QDir::separator()+".datatex"+QDir::separator();
-    QDir dir(datatexpath);
-    if (!dir.exists())dir.mkpath(datatexpath);
+    SessionManager::instance().datatexpath = QDir::homePath()+QDir::separator()+".datatex"+QDir::separator();
+    QDir dir(SessionManager::instance().datatexpath);
+    if (!dir.exists())dir.mkpath(SessionManager::instance().datatexpath);
 
-    QString Bibliography_Settings_Path = datatexpath+"Bibliography_Settings.db";
-    QString CTANDatabasePath = datatexpath+"CTANPackagesDatabase.db";
+    QString Bibliography_Settings_Path = SessionManager::instance().datatexpath+"Bibliography_Settings.db";
+    QString CTANDatabasePath = SessionManager::instance().datatexpath+"CTANPackagesDatabase.db";
     if(!QFileInfo::exists(Bibliography_Settings_Path)){
         QFile Settings(":/databases/Bibliography_Settings.db");
         Settings.copy(Bibliography_Settings_Path);
@@ -1202,15 +1168,15 @@ void DataTex::SettingsDatabase_Variables()
     // Bibliography_Settings.open();
     QSettings settings;
     settings.beginGroup("LaTeX");
-    CurrentPreamble = settings.value("CurrentPreamble").toString();
+    SessionManager::instance().CurrentPreamble = settings.value("CurrentPreamble").toString();
     settings.endGroup();
 
     DTXSettings dtxsettings;
-    DTXBuildCommands = dtxsettings.setDTXBuildCommands();
-    CurrentPreamble_Content = dtxsettings.getCurrentPreambleContent(CurrentPreamble);
+    SessionManager::instance().DTXBuildCommands = dtxsettings.setDTXBuildCommands();
+    SessionManager::instance().CurrentPreamble_Content = dtxsettings.getCurrentPreambleContent(SessionManager::instance().CurrentPreamble);
     // int index = 0;
     // move function to latexEditor.cpp?
-    for (auto i = DTXBuildCommands.cbegin(), end = DTXBuildCommands.cend(); i != end; i++){
+    for (auto i = SessionManager::instance().DTXBuildCommands.cbegin(), end = SessionManager::instance().DTXBuildCommands.cend(); i != end; i++){
         DTXBuildCommand command = i.value();
         qDebug()<<i.key()<<command.Id<<(command.CommandType == "Build");
         if(command.CommandType == "Build"){
@@ -1332,7 +1298,7 @@ QAction * DataTex::CreateNewAction(QMenu * Menu, QAction * Action, std::function
 
 void DataTex::NewDatabaseBaseFile()
 {
-    if (CurrentFilesDataBase.Path.isEmpty() || CurrentFilesDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                      tr("Error"),tr("No Files database created.\nDo you wish to create a new database?"),
                      QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1351,7 +1317,7 @@ void DataTex::NewDatabaseBaseFile()
 
 void DataTex::NewGraphicsFile()
 {
-    if (CurrentFilesDataBase.Path.isEmpty() || CurrentFilesDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                                                                   tr("Error"),tr("No Files database created.\nDo you wish to create a new database?"),
                                                                   QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1370,7 +1336,7 @@ void DataTex::NewGraphicsFile()
 
 void DataTex::NewTableFile()
 {
-    if (CurrentFilesDataBase.Path.isEmpty() || CurrentFilesDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                                                                   tr("Error"),tr("No Files database created.\nDo you wish to create a new database?"),
                                                                   QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1391,14 +1357,14 @@ void DataTex::NewFileAddedToDatabase(QString filePath)
 {
     // Load and show new entry in table
     ShowDataBaseFiles();
-    SelectNewFileInModel(FilesTable,QFileInfo(filePath).baseName());
+    SessionManager::instance().SelectNewFileInModel(FilesTable,QFileInfo(filePath).baseName());
     ui->PreviewStackedWidget->setCurrentIndex(2);
-    DBBackUp(CurrentFilesDataBase.Path,datatexpath+QFileInfo(CurrentFilesDataBase.Path).fileName());
+    SessionManager::instance().DBBackUp(SessionManager::instance().CurrentFilesDataBase.Path,SessionManager::instance().datatexpath+QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).fileName());
 }
 
 void DataTex::SolutionFile()
 {
-    if (DataTex::CurrentFilesDataBase.Path.isEmpty() || DataTex::CurrentFilesDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                      "Error",tr("No Files database created.\nDo you wish to create a new database?"),
                      QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1419,8 +1385,8 @@ void DataTex::SolutionFile()
         });
         connect(newsoldialog,&SolveDatabaseExercise::on_close,this,[=](QString newSolution){
             ShowDataBaseFiles();
-            SelectNewFileInModel(FilesTable,newSolution);
-            DBBackUp(CurrentFilesDataBase.Path,datatexpath+QFileInfo(CurrentFilesDataBase.Path).fileName());
+            SessionManager::instance().SelectNewFileInModel(FilesTable,newSolution);
+            SessionManager::instance().DBBackUp(SessionManager::instance().CurrentFilesDataBase.Path,SessionManager::instance().datatexpath+QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).fileName());
         });
         newsoldialog->show();
         newsoldialog->activateWindow();
@@ -1429,9 +1395,9 @@ void DataTex::SolutionFile()
 
 void DataTex::InsertFiles()
 {
-    DTXDocument * docInfo = new DTXDocument(DocumentFileName,CurrentDocumentsDataBase.Database);
+    DTXDocument * docInfo = new DTXDocument(DocumentFileName,SessionManager::instance().CurrentDocumentsDataBase.Database);
     docInfo->WriteDTexFile();
-    if (DataTex::CurrentDocumentsDataBase.Path.isEmpty() || DataTex::CurrentDocumentsDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentDocumentsDataBase.Path.isEmpty() || SessionManager::instance().CurrentDocumentsDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                      "Error",tr("No Document database created.\nDo you wish to create a new database?"),
                      QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1449,8 +1415,8 @@ void DataTex::InsertFiles()
 
 void DataTex::PersonalNotes()
 {
-    if (DataTex::CurrentFilesDataBase.Path.isEmpty() || DataTex::CurrentFilesDataBase.Path.isNull() ||
-            DataTex::CurrentDocumentsDataBase.Path.isEmpty() || DataTex::CurrentDocumentsDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull() ||
+            SessionManager::instance().CurrentDocumentsDataBase.Path.isEmpty() || SessionManager::instance().CurrentDocumentsDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                      "Error",tr("No Document database created.\nDo you wish to create a new database?"),
                      QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1493,15 +1459,15 @@ void DataTex::CreateNewDocument(DTXDocument docInfo)
     writeContent << docInfo.Content;
     file.close();
     ShowDocuments();
-    SelectNewFileInModel(FilesTable,docInfo.Id);
-    DBBackUp(CurrentDocumentsDataBase.Path,datatexpath+QFileInfo(CurrentDocumentsDataBase.Path).fileName());
+    SessionManager::instance().SelectNewFileInModel(FilesTable,docInfo.Id);
+    SessionManager::instance().DBBackUp(SessionManager::instance().CurrentDocumentsDataBase.Path,SessionManager::instance().datatexpath+QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).fileName());
     docInfo.WriteDTexFile();
 }
 
 void DataTex::DataBaseFields()
 {
-    if (DataTex::CurrentFilesDataBase.Path.isEmpty() || DataTex::CurrentFilesDataBase.Path.isNull() ||
-            DataTex::CurrentDocumentsDataBase.Path.isEmpty() || DataTex::CurrentDocumentsDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull() ||
+            SessionManager::instance().CurrentDocumentsDataBase.Path.isEmpty() || SessionManager::instance().CurrentDocumentsDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                      "Error",tr("No Files or Document database created.\nDo you wish to create a new database?"),
                      QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1518,8 +1484,8 @@ void DataTex::DataBaseFields()
 
 void DataTex::CreateSolutionsDocument()
 {
-    if (DataTex::CurrentFilesDataBase.Path.isEmpty() || DataTex::CurrentFilesDataBase.Path.isNull() ||
-            DataTex::CurrentDocumentsDataBase.Path.isEmpty() || DataTex::CurrentDocumentsDataBase.Path.isNull()){
+    if (SessionManager::instance().CurrentFilesDataBase.Path.isEmpty() || SessionManager::instance().CurrentFilesDataBase.Path.isNull() ||
+            SessionManager::instance().CurrentDocumentsDataBase.Path.isEmpty() || SessionManager::instance().CurrentDocumentsDataBase.Path.isNull()){
         QMessageBox::StandardButton resBtn = QMessageBox::warning( this,
                      "Error",tr("No Files database created and a Notes Database.\nDo you wish to create a new database?"),
                      QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
@@ -1593,7 +1559,7 @@ void DataTex::DatabaseSyncFiles()
 
 void DataTex::EditFileMeta()
 {
-    DTXFile *meta = new DTXFile(DatabaseFileName,CurrentFilesDataBase.Database);
+    DTXFile *meta = new DTXFile(DatabaseFileName,SessionManager::instance().CurrentFilesDataBase.Database);
     NewDatabaseFile * Edit = new NewDatabaseFile(this,meta,NewFileMode::EditMode);
     connect(Edit,SIGNAL(acceptSignal(QString)),this,
             SLOT(NewFileAddedToDatabase(QString)));
@@ -1611,20 +1577,20 @@ void DataTex::EditDocumentDialog()
 
 void DataTex::ShowDataBaseFiles()
 {
-    FilesTable->filterTable("SELECT * FROM FilesDBView"/*SqlFunctions::ShowAllDatabaseFiles*/,CurrentFilesDataBase.Database,filesSorting);
+    FilesTable->filterTable("SELECT * FROM FilesDBView"/*SqlFunctions::ShowAllDatabaseFiles*/,SessionManager::instance().CurrentFilesDataBase.Database,filesSorting);
     FilesTable->show();
     int columns = FilesTable->model()->columnCount();
     FilesTable->generateFilters(columns,false);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this,[=](){
-        FilesTable_selectionchanged(CurrentDTXDataBase.Type);
+        FilesTable_selectionchanged(SessionManager::instance().CurrentDTXDataBase.Type);
     });
     connect(FilesTable->filterHeader(), &FilterTableHeader::filterValues, this, &DataTex::updateFilter);
     connect(FilesTable->filterHeader(), &FilterTableHeader::filterValues, this, [=](){ui->ClearFiltersFD->setEnabled(true);});
-    LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
     for (int i=0;i<FilesTable->model()->columnCount();i++ ) {
         FilesTable->filterHeader()->placeHolderText(i,FilesTable->model()->headerData(i,Qt::Horizontal,Qt::DisplayRole).toString()+"...");
     }
-    StretchColumns(FilesTable,1.5);
+    SessionManager::instance().StretchColumns(FilesTable,1.5);
 }
 
 void DataTex::updateFilter(QStringList values)
@@ -1635,15 +1601,15 @@ void DataTex::updateFilter(QStringList values)
         FilesTable->setColumnHidden(columns,true);
         FilesTable->setColumnHidden(columns+1,true);
         FilesTable->setColumnHidden(columns+2,true);
-        updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,CurrentFilesDataBase.Database,this);
-        FilesTable->filterTable(SqlFunctions::FilesTable_UpdateQuery,CurrentFilesDataBase.Database,filesSorting);
+        SessionManager::instance().updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,SessionManager::instance().CurrentFilesDataBase.Database,this);
+        FilesTable->filterTable(SqlFunctions::FilesTable_UpdateQuery,SessionManager::instance().CurrentFilesDataBase.Database,filesSorting);
         //------
         connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this,[=](){
-            FilesTable_selectionchanged(CurrentDTXDataBase.Type);
+            FilesTable_selectionchanged(SessionManager::instance().CurrentDTXDataBase.Type);
         });
-        LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+        SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
         connect(FilesTable,&ExtendedTableWidget::filesfound,this,[=](int files){
-            ui->CurrentBaseLabel->setText(CurrentFilesDataBase.BaseName+" : "+QString::number(files)/*FileCount(CurrentFilesDataBase.Database,FilesTable)*/+tr(" files"));
+            ui->CurrentBaseLabel->setText(SessionManager::instance().CurrentFilesDataBase.BaseName+" : "+QString::number(files)/*FileCount(SessionManager::instance().CurrentFilesDataBase.Database,FilesTable)*/+tr(" files"));
         });
     }
     else if(ui->stackedWidget->currentIndex()==2){
@@ -1667,13 +1633,13 @@ void DataTex::updateFilter(QStringList values)
         }
         SqlFunctions::FilterDatabaseDocuments += DataFields.join(" AND ");
         SqlFunctions::FilterDatabaseDocuments += " GROUP BY d.Id ORDER BY d.rowid;";
-        updateTableView(FilesTable,SqlFunctions::FilterDatabaseDocuments,CurrentDocumentsDataBase.Database,this);//
-        FilesTable->filterTable(SqlFunctions::FilterDatabaseDocuments,CurrentDocumentsDataBase.Database,docsSorting);
+        SessionManager::instance().updateTableView(FilesTable,SqlFunctions::FilterDatabaseDocuments,SessionManager::instance().CurrentDocumentsDataBase.Database,this);//
+        FilesTable->filterTable(SqlFunctions::FilterDatabaseDocuments,SessionManager::instance().CurrentDocumentsDataBase.Database,docsSorting);
         //------
         connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this,[=](){
-            FilesTable_selectionchanged(CurrentDTXDataBase.Type);
+            FilesTable_selectionchanged(SessionManager::instance().CurrentDTXDataBase.Type);
         });
-        LoadTableHeaders(FilesTable,Database_DocTableFieldNames);
+        SessionManager::instance().LoadTableHeaders(FilesTable,Database_DocTableFieldNames);
     }
     else if(ui->stackedWidget->currentIndex()==3){
         SqlFunctions::FilterBibliographyEntries.clear();
@@ -1692,24 +1658,24 @@ void DataTex::updateFilter(QStringList values)
         SqlFunctions::FilterBibliographyEntries += DataFields.join(" AND ");
         SqlFunctions::FilterBibliographyEntries += " ORDER BY b.ROWID ";
         // qDebug()<<SqlFunctions::FilterBibliographyEntries;
-        // updateTableView(FilesTable,SqlFunctions::FilterBibliographyEntries,Bibliography_Settings,this);
+        // SessionManager::instance().updateTableView(FilesTable,SqlFunctions::FilterBibliographyEntries,Bibliography_Settings,this);
     }
 }
 
 void DataTex::ShowDocuments()
 {
-    FilesTable->filterTable(SqlFunctions::ShowDocuments,CurrentDocumentsDataBase.Database,docsSorting);
+    FilesTable->filterTable(SqlFunctions::ShowDocuments,SessionManager::instance().CurrentDocumentsDataBase.Database,docsSorting);
     int columns = FilesTable->model()->columnCount();
     FilesTable->generateFilters(columns,false);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this,[=](){
-        FilesTable_selectionchanged(CurrentDTXDataBase.Type);
+        FilesTable_selectionchanged(SessionManager::instance().CurrentDTXDataBase.Type);
     });
     connect(FilesTable->filterHeader(), &FilterTableHeader::filterValues, this, &DataTex::updateFilter);
-    LoadTableHeaders(FilesTable,Database_DocTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_DocTableFieldNames);
     for (int i=0;i<FilesTable->model()->columnCount();i++ ) {
         FilesTable->filterHeader()->placeHolderText(i,FilesTable->model()->headerData(i,Qt::Horizontal,Qt::DisplayRole).toString()+"...");
     }
-    StretchColumns(FilesTable,1.5);
+    SessionManager::instance().StretchColumns(FilesTable,1.5);
 }
 void DataTex::ShowBibliography()
 {
@@ -1735,11 +1701,11 @@ void DataTex::ShowBibliography()
 //    connect(BibliographyTable->filterHeader(), &FilterTableHeader::filterValues, this, &DataTex::updateFilter);
 //    connect(BibliographyTable->filterHeader(), &FilterTableHeader::filterValues, this, [=](){ui->ClearFiltersB->setEnabled(true);});
 ////    QStringList list = SqlFunctions::Get_StringList_From_Query("SELECT name FROM Bibliography_Fields ORDER BY ROWID",DataTex::Bibliography_Settings);
-//    LoadTableHeaders(BibliographyTable,BibliographyTableColumns);
+//    SessionManager::instance().LoadTableHeaders(BibliographyTable,BibliographyTableColumns);
 //    for (int i=0;i<BibliographyTable->model()->columnCount();i++ ) {
 //        BibliographyTable->filterHeader()->placeHolderText(i,BibliographyTable->model()->headerData(i,Qt::Horizontal,Qt::DisplayRole).toString()+"...");
 //    }
-//    StretchColumns(BibliographyTable,1.5);
+//    SessionManager::instance().StretchColumns(BibliographyTable,1.5);
 }
 
 void DataTex::FilesTable_selectionchanged(int DatabaseType)
@@ -1812,14 +1778,14 @@ void DataTex::FilesTable_selectionchanged(int DatabaseType)
 //    ui->DateTimeEdit->setText(QDateTime::fromString(Date,"dd/M/yyyy hh:mm").toString("dddd d MMMM yyyy hh:mm"));
 //    ui->DifficultySpinBox->setText(QString::number(Difficulty));
     int m=0;
-    for(int k:CurrentFilesDataBase.basicVisibleFieldIndexes()){
+    for(int k:SessionManager::instance().CurrentFilesDataBase.basicVisibleFieldIndexes()){
         if(!FilesTable->isColumnHidden(k)){
             valuelabelList[m]->setText(FilesTable->model()->data(FilesTable->model()->index(row,k)).toString());
             m++;
         }
     }
-    QSqlQuery OptionalValues(DataTex::CurrentFilesDataBase.Database);
-    OptionalValues.exec(QString("SELECT %1 FROM Database_Files WHERE Id = \"%2\"").arg(CurrentFilesDataBase.customFieldIds().join(","),DatabaseFileName));
+    QSqlQuery OptionalValues(SessionManager::instance().CurrentFilesDataBase.Database);
+    OptionalValues.exec(QString("SELECT %1 FROM Database_Files WHERE Id = \"%2\"").arg(SessionManager::instance().CurrentFilesDataBase.customFieldIds().join(","),DatabaseFileName));
     while(OptionalValues.next()){
         QSqlRecord record = OptionalValues.record();
         for(int i=0; i < record.count(); i++)
@@ -1828,7 +1794,7 @@ void DataTex::FilesTable_selectionchanged(int DatabaseType)
         }
     }
 
-//    ui->SolutionsLine->setText(SqlFunctions::Get_String_From_Query(QString("SELECT COUNT(*) FROM Solutions_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),CurrentFilesDataBase.Database)+tr(" solutions/proofs"));
+//    ui->SolutionsLine->setText(SqlFunctions::Get_String_From_Query(QString("SELECT COUNT(*) FROM Solutions_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),SessionManager::instance().CurrentFilesDataBase.Database)+tr(" solutions/proofs"));
 
     ui->FileDescription->setText(FileDescription);
 
@@ -1853,10 +1819,10 @@ void DataTex::FilesTable_selectionchanged(int DatabaseType)
                                    Solvable != (int)DTXSolutionState::SolutionIncomplete);
 
     int modified = SqlFunctions::Get_String_From_Query(
-        QString("SELECT COUNT(*) FROM Edit_History WHERE File_Id = '%1'").arg(DatabaseFileName),CurrentDTXDataBase.Database).toInt();
+        QString("SELECT COUNT(*) FROM Edit_History WHERE File_Id = '%1'").arg(DatabaseFileName),SessionManager::instance().CurrentDTXDataBase.Database).toInt();
     FileEditHistory->setEnabled(modified>0);
 
-//    QStringList BibEntriesInFile = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM Bib_Entries_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),CurrentFilesDataBase.Database);
+//    QStringList BibEntriesInFile = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM Bib_Entries_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),SessionManager::instance().CurrentFilesDataBase.Database);
 //    ui->BibEntriesCombo->clear();
 //    QSqlQuery listOfBibEntries(Bibliography_Settings);
 //    listOfBibEntries.exec("SELECT * FROM EntrySourceCode");
@@ -1894,20 +1860,21 @@ void DataTex::FilesTable_selectionchanged(int DatabaseType)
 //    }
 
     FilesPreambleCombo->setEnabled(true);
-    CurrentPreamble = FilesTable->model()->data(FilesTable->model()->index(row,12)).toString();
-    int index = FilesPreambleCombo->findData(CurrentPreamble);
+    SessionManager::instance().CurrentPreamble = FilesTable->model()->data(FilesTable->model()->index(row,12)).toString();
+    int index = FilesPreambleCombo->findData(SessionManager::instance().CurrentPreamble);
     FilesPreambleCombo->setCurrentIndex(index);
     DTXSettings settings;
-    CurrentPreamble_Content = settings.getCurrentPreambleContent(CurrentPreamble);
-    // qDebug()<<CurrentPreamble_Content;
+    SessionManager::instance().CurrentPreamble_Content = settings.getCurrentPreambleContent(SessionManager::instance().CurrentPreamble);
+    // qDebug()<<SessionManager::instance().CurrentPreamble_Content;
     getActionFromText(CompileMenu,CompileCommands);
 
-    QSqlQuery FilesQuery(CurrentDocumentsDataBase.Database);
-    QSqlQueryModel * Files = new QSqlQueryModel(this);
-//    for (int i=0;i<GlobalDatabaseList.values().count();i++) {
-//        if(GlobalDatabaseList.values().at(i)!=CurrentDocumentsDataBase.Path) {
-//            FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(GlobalDatabaseList.values().at(i),QFileInfo(GlobalDatabaseList.values().at(i)).baseName()));
-//            datalist.append(SqlFunctions::ShowFilesInADocument_DifferentDatabase.arg(files,GlobalDatabaseList[QFileInfo(DatabasesInADocument.at(i)).baseName()]
+    QSqlQuery FilesQuery(SessionManager::instance().CurrentDocumentsDataBase.Database);
+    if(ui->FileDependenciesTable->model()) ui->FileDependenciesTable->model()->deleteLater();
+    QSqlQueryModel * Files = new QSqlQueryModel(ui->FileDependenciesTable);
+//    for (int i=0;i<SessionManager::instance().GlobalDatabaseList.values().count();i++) {
+//        if(SessionManager::instance().GlobalDatabaseList.values().at(i)!=SessionManager::instance().CurrentDocumentsDataBase.Path) {
+//            FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(SessionManager::instance().GlobalDatabaseList.values().at(i),QFileInfo(SessionManager::instance().GlobalDatabaseList.values().at(i)).baseName()));
+//            datalist.append(SqlFunctions::ShowFilesInADocument_DifferentDatabase.arg(files,SessionManager::instance().GlobalDatabaseList[QFileInfo(DatabasesInADocument.at(i)).baseName()]
 //                                                                                     ,QFileInfo(DatabasesInADocument.at(i)).baseName()));
 //        }
 //    }
@@ -1921,7 +1888,7 @@ void DataTex::FilesTable_selectionchanged(int DatabaseType)
     ui->FileDependenciesTable->show();
     ui->FileDependenciesTable->setColumnHidden(2,true);
     ui->FileDependenciesTable->setColumnHidden(3,true);
-    StretchColumnsToWidth(ui->FileDependenciesTable);
+    SessionManager::instance().StretchColumnsToWidth(ui->FileDependenciesTable);
     connect(ui->FileDependenciesTable->selectionModel(), &QItemSelectionModel::selectionChanged,
             this,[&](){
         int row = ui->FileDependenciesTable->currentIndex().row();
@@ -2015,7 +1982,7 @@ void DataTex::DocumentsTable_selectionChanged()
     DocumentDescription = FilesTable->model()->data(FilesTable->model()->index(row,14)).toString();
 
     QStringList ListOfDatabases =
-            SqlFunctions::Get_StringList_From_Query(QString("SELECT DISTINCT Files_Database_Source FROM Files_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName),CurrentDocumentsDataBase.Database);
+            SqlFunctions::Get_StringList_From_Query(QString("SELECT DISTINCT Files_Database_Source FROM Files_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName),SessionManager::instance().CurrentDocumentsDataBase.Database);
     DatabasesInADocument.clear();
     DatabasesInADocument = {};
 //            SqlFunctions::Get_StringList_From_Query(QString("SELECT Path FROM Databases WHERE FileName IN (\"%1\")").arg(ListOfDatabases.join("\",\""))
@@ -2041,16 +2008,17 @@ void DataTex::DocumentsTable_selectionChanged()
     // qDebug()<<exerciseOrder;
     TexFile.close();
     QString files = "(\""+fileNamesInDocument.join("\",\"")+"\")";
-    QSqlQueryModel * Files = new QSqlQueryModel(this);
+    if(ui->TexFileTable->model()) ui->TexFileTable->model()->deleteLater();
+    QSqlQueryModel * Files = new QSqlQueryModel(ui->TexFileTable);
     QStringList datalist;
     QString query;
-    QSqlQuery FilesQuery(CurrentFilesDataBase.Database);
+    QSqlQuery FilesQuery(SessionManager::instance().CurrentFilesDataBase.Database);
     for (int i=0;i<DatabasesInADocument.count();i++) {
-        // qDebug()<<DatabasesInADocument.at(i)<<" = "<<CurrentFilesDataBase.Path;
-        QString name = (DatabasesInADocument.at(i)!=CurrentFilesDataBase.Path) ? QFileInfo(DatabasesInADocument.at(i)).baseName() : "main" ;
-        datalist.append(SqlFunctions::ShowFilesInADocument.arg(files,GlobalDatabaseList.value(QFileInfo(DatabasesInADocument.at(i)).baseName()).Description
+        // qDebug()<<DatabasesInADocument.at(i)<<" = "<<SessionManager::instance().CurrentFilesDataBase.Path;
+        QString name = (DatabasesInADocument.at(i)!=SessionManager::instance().CurrentFilesDataBase.Path) ? QFileInfo(DatabasesInADocument.at(i)).baseName() : "main" ;
+        datalist.append(SqlFunctions::ShowFilesInADocument.arg(files,SessionManager::instance().GlobalDatabaseList.value(QFileInfo(DatabasesInADocument.at(i)).baseName()).Description
                         ,name));
-        if(DatabasesInADocument.at(i)!=CurrentFilesDataBase.Path) {
+        if(DatabasesInADocument.at(i)!=SessionManager::instance().CurrentFilesDataBase.Path) {
             FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(DatabasesInADocument.at(i),QFileInfo(DatabasesInADocument.at(i)).baseName()));
             // qDebug()<<QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(DatabasesInADocument.at(i),QFileInfo(DatabasesInADocument.at(i)).baseName());
         }
@@ -2062,11 +2030,11 @@ void DataTex::DocumentsTable_selectionChanged()
     Files->setQuery(FilesQuery);
     ui->TexFileTable->setModel(Files);
     ui->TexFileTable->show();
-    LoadTableHeaders(ui->TexFileTable,{tr("Id"),tr("Database source"),tr("File type"),tr("Section")
+    SessionManager::instance().LoadTableHeaders(ui->TexFileTable,{tr("Id"),tr("Database source"),tr("File type"),tr("Section")
                                         ,tr("Exercise type"),tr("Path"),tr("Solved - Prooved")});
     ui->TexFileTable->setColumnHidden(7,true);
     ui->TexFileTable->setColumnHidden(8,true);
-    StretchColumns(ui->TexFileTable,1.5);
+    SessionManager::instance().StretchColumns(ui->TexFileTable,1.5);
 //    QSet<QString> FilesMissingFromDatabaseEntries = fileNamesInDocument.toSet().subtract(filesFromDatabase.toSet());
 //    QSet<QString> FilesMissingFromDocument = filesFromDatabase.toSet().subtract(fileNamesInDocument.toSet());
 //    foreach (const QString &filename, FilesMissingFromDatabaseEntries)
@@ -2097,8 +2065,8 @@ void DataTex::DocumentsTable_selectionChanged()
 //                                    ui->TexFileTable->model()->data(DocumentsTable->model()->index(i,1)).toString());
 //    }
 
-    DocOptionalFields = Optional_DocMetadata_Ids[QFileInfo(CurrentDocumentsDataBase.Path).baseName()].join(",");
-    QSqlQuery OptionalValues(DataTex::CurrentDocumentsDataBase.Database);
+    DocOptionalFields = SessionManager::instance().Optional_DocMetadata_Ids[QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()].join(",");
+    QSqlQuery OptionalValues(SessionManager::instance().CurrentDocumentsDataBase.Database);
     OptionalValues.exec(QString("SELECT %1 FROM Database_Files WHERE Id = \"%2\"").arg(DocOptionalFields,DocumentFileName));
     QStringList s;
     while(OptionalValues.next()){
@@ -2116,9 +2084,9 @@ void DataTex::DocumentsTable_selectionChanged()
         QString db = ui->TexFileTable->model()->data(ui->TexFileTable->model()->index(i,9)).toString();
 
         QString File = ui->TexFileTable->model()->data(ui->TexFileTable->model()->index(i,0)).toString();
-        QString DatabaseName = (db != "main") ? db : CurrentFilesDataBase.BaseName ;
+        QString DatabaseName = (db != "main") ? db : SessionManager::instance().CurrentFilesDataBase.BaseName ;
         QString FileType = ui->TexFileTable->model()->data(ui->TexFileTable->model()->index(i,7)).toString();
-        QSqlDatabase Database = GlobalDatabaseList.value(DatabaseName).Database;
+        QSqlDatabase Database = SessionManager::instance().GlobalDatabaseList.value(DatabaseName).Database;
         QStringList list = SqlFunctions::Get_StringList_From_Query(QString("SELECT Solvable FROM FileTypes WHERE Id = '%1'").arg(FileType),Database);
         int solvable = (list.count()>0) ? list[0].toInt() : 0 ;
         QStringList Solutions_per_exer =
@@ -2176,7 +2144,7 @@ void DataTex::DocumentsTable_selectionChanged()
         // }
     }
 
-    QSqlQuery IndividualEntries(CurrentDocumentsDataBase.Database);
+    QSqlQuery IndividualEntries(SessionManager::instance().CurrentDocumentsDataBase.Database);
     IndividualEntries.exec(QString("SELECT Bib_Id FROM BibEntries_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName));
     while(IndividualEntries.next()){
         int i = -1;
@@ -2197,7 +2165,7 @@ void DataTex::DocumentsTable_selectionChanged()
             ui->BibPerFileTree->topLevelItem(1)->addChild(item);
             item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable);
             item->setCheckState(0,Qt::Checked);
-//            foreach(QSqlDatabase database,GlobalDatabaseList.values()){
+//            foreach(QSqlDatabase database,SessionManager::instance().GlobalDatabaseList.values()){
 //                QSqlQuery FilesPerEntry(database);
 //                FilesPerEntry.exec(QString("SELECT File_Id,Path "
 //                                           "FROM Bib_Entries_per_File bpf "
@@ -2219,7 +2187,7 @@ void DataTex::DocumentsTable_selectionChanged()
     ui->SaveDocBibContent->setEnabled(false);
 
     int modified = SqlFunctions::Get_String_From_Query(
-        QString("SELECT COUNT(*) FROM Edit_History WHERE File_Id = '%1'").arg(DocumentFileName),CurrentDocumentsDataBase.Database).toInt();
+        QString("SELECT COUNT(*) FROM Edit_History WHERE File_Id = '%1'").arg(DocumentFileName),SessionManager::instance().CurrentDocumentsDataBase.Database).toInt();
     DocEditHistory->setEnabled(modified>0);
 
     // QSqlQuery listOfBibEntries(Bibliography_Settings);
@@ -2254,7 +2222,7 @@ void DataTex::BibliographyTable_selectionChanged()
 //    Editors = BibliographyTable->model()->data(BibliographyTable->model()->index(row,4)).toString();
 //    Bib_ValueList["editor"]->setText(Editors);
 //    Translators = BibliographyTable->model()->data(BibliographyTable->model()->index(row,5)).toString();
-//    Bib_ValueList["translator"]->setText(Translators);
+//    Bib_ValueList["SessionManager::instance().translator"]->setText(Translators);
 //    Publisher = BibliographyTable->model()->data(BibliographyTable->model()->index(row,6)).toString();
 //    Bib_ValueList["publisher"]->setText(Publisher);
 //    BibYear = BibliographyTable->model()->data(BibliographyTable->model()->index(row,7)).toInt();
@@ -2320,18 +2288,18 @@ void DataTex::BibliographyTable_selectionChanged()
 //    DeleteBibEntry->setEnabled(true);
 
 //    QSqlQueryModel * Files = new QSqlQueryModel(this);
-//    QSqlQuery Query(CurrentFilesDataBase.Database);
+//    QSqlQuery Query(SessionManager::instance().CurrentFilesDataBase.Database);
 //    QStringList datalist;
 //    QString text = QString("SELECT File_Id,\"%2\" AS \"Database source\", df.Path "
 //                           "FROM Bib_Entries_per_File bpf "
 //                           "JOIN Database_Files df ON df.Id = bpf.File_Id WHERE Bib_Id = '%1' ")
-//            .arg(CitationKey,CurrentFilesDataBase.BaseName);
+//            .arg(CitationKey,SessionManager::instance().CurrentFilesDataBase.BaseName);
 //    datalist.append(text);
 //    int i=-1;
-//    for (DTXDatabase DTXDB : GlobalDatabaseList) {
+//    for (DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList) {
 //        i++;
-//        QString DataPath = DTXDatabase(GlobalDatabaseList.values()[i]).Path;
-//        if(DataPath!=CurrentFilesDataBase.Path) {
+//        QString DataPath = DTXDatabase(SessionManager::instance().GlobalDatabaseList.values()[i]).Path;
+//        if(DataPath!=SessionManager::instance().CurrentFilesDataBase.Path) {
 //            Query.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(DTXDB.Path,DTXDB.BaseName));
 //            datalist.append(QString("SELECT File_Id,\"%3\" AS \"Database source\", df.Path "
 //                                    "FROM %2.Bib_Entries_per_File bpf "
@@ -2347,7 +2315,7 @@ void DataTex::BibliographyTable_selectionChanged()
 //    ui->DatabaseFiles_per_BibEntry->show();
 //    QString label = "Database files that contain entry "+CitationKey+" : "+QString::number(ui->DatabaseFiles_per_BibEntry->model()->rowCount())+" files";
 //    ui->CitationsLabel->setText(label);
-//    StretchColumnsToWidth(ui->DatabaseFiles_per_BibEntry);
+//    SessionManager::instance().StretchColumnsToWidth(ui->DatabaseFiles_per_BibEntry);
 //    connect(ui->DatabaseFiles_per_BibEntry->selectionModel(), &QItemSelectionModel::selectionChanged,this,[=](){
 //        QItemSelectionModel *select2 = ui->DatabaseFiles_per_BibEntry->selectionModel();
 //        int index = -1;
@@ -2369,7 +2337,7 @@ void DataTex::BibliographyTable_selectionChanged()
 //        view->openFile(pdfFile,"","");
 //    }
 //    else{
-//        view->openFile(DataTex::GlobalSaveLocation+"No_Pdf.pdf","","");
+//        view->openFile(SessionManager::instance().GlobalSaveLocation+"No_Pdf.pdf","","");
 //    }
 //}
 
@@ -2382,7 +2350,7 @@ void DataTex::BibliographyTable_selectionChanged()
     //        view->setCurrentDocument(pdfFile);
     //    }
     //    else{
-    //        view->setCurrentDocument(DataTex::GlobalSaveLocation+"No_Pdf.pdf");
+    //        view->setCurrentDocument(SessionManager::instance().GlobalSaveLocation+"No_Pdf.pdf");
     //    }
 //}
 
@@ -2390,7 +2358,7 @@ void DataTex::CompileToPdf()
 {
     QAction * action = qobject_cast<QAction*>(sender());
     ui->FileEdit->toolBar->Save->trigger();
-    CurrentPreamble = FilesPreambleCombo->currentData().toString();
+    SessionManager::instance().CurrentPreamble = FilesPreambleCombo->currentData().toString();
     setPreamble();
     FileCommands::CreateTexFile(DatabaseFilePath,DocumentUseBibliography,StuffToAddToPreamble);
     FileCommands::BuildDocument(action->data().value<DTXBuildCommand>(),DatabaseFilePath);
@@ -2414,7 +2382,7 @@ void DataTex::CompileAsymptote()
 
     QProcess compileProcess;
     compileProcess.setWorkingDirectory(QFileInfo(DatabaseFilePath).absolutePath());
-    compileProcess.start(DataTex::Asymptote_Command,Files);
+    compileProcess.start(SessionManager::instance().Asymptote_Command,Files);
     compileProcess.waitForFinished(-1);
 }
 
@@ -2435,7 +2403,7 @@ void DataTex::CreateNewDatabase(DTXDatabase DTXDB)
     database.setDatabaseName(FullPath);
     database.setConnectOptions("QSQLITE_ENABLE_REGEXP");
     DTXDB.Database = database;
-    GlobalDatabaseList.insert(DTXDB.BaseName,DTXDB);
+    SessionManager::instance().GlobalDatabaseList.insert(DTXDB.BaseName,DTXDB);
     ui->SideBarButtonGroup->button(DTXDB.Type+1);
     ui->OpenDatabasesTreeWidget->setCurrentItem(ui->OpenDatabasesTreeWidget->topLevelItem(DTXDB.Type)->child(ui->OpenDatabasesTreeWidget->topLevelItem(DTXDB.Type)->childCount()-1));
     on_OpenDatabasesTreeWidget_itemClicked(ui->OpenDatabasesTreeWidget->topLevelItem(DTXDB.Type)->child(ui->OpenDatabasesTreeWidget->topLevelItem(DTXDB.Type)->childCount()-1),0);
@@ -2452,9 +2420,9 @@ void DataTex::UpdateCurrentDatabase(DTXDatabase DTXDB)
         settings.setValue("CurrentDB",baseName);
         settings.endGroup();
         if(!DTXDB.Encrypt){
-            CurrentFilesDataBase = DTXDB;
-            Database_FileTableFields = CurrentFilesDataBase.getIdsList();
-            Database_FileTableFieldNames = CurrentFilesDataBase.getNamesList();
+            SessionManager::instance().CurrentFilesDataBase = DTXDB;
+            Database_FileTableFields = SessionManager::instance().CurrentFilesDataBase.getIdsList();
+            Database_FileTableFieldNames = SessionManager::instance().CurrentFilesDataBase.getNamesList();
 //            ShowMetadataInfo();
             // qDebug()<<Database_FileTableFields;
             SqlFunctions::ShowAllFiles(Database_FileTableFields);
@@ -2464,7 +2432,7 @@ void DataTex::UpdateCurrentDatabase(DTXDatabase DTXDB)
         }
         connect(FilesTable,&ExtendedTableWidget::filesfound,this,[=](int files){
             // qDebug()<<"filecount=0"<<files;
-            ui->CurrentBaseLabel->setText(GlobalDatabaseList.value(baseName).Description+" : "+QString::number(files)/*FileCount(CurrentFilesDataBase.Database,FilesTable)*/+tr(" files"));
+            ui->CurrentBaseLabel->setText(SessionManager::instance().GlobalDatabaseList.value(baseName).Description+" : "+QString::number(files)/*FileCount(SessionManager::instance().CurrentFilesDataBase.Database,FilesTable)*/+tr(" files"));
         });
         break;
     case DTXDatabaseType::DocumentsDB:
@@ -2473,10 +2441,10 @@ void DataTex::UpdateCurrentDatabase(DTXDatabase DTXDB)
         settings.setValue("CurrentDB",baseName);
         settings.endGroup();
         if(!DTXDB.Encrypt){
-            CurrentDocumentsDataBase = DTXDB;
-            Database_DocumentTableColumns = SqlFunctions::Get_StringList_From_Query("SELECT name FROM pragma_table_info('Documents')",CurrentDocumentsDataBase.Database);
-            Database_DocTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",CurrentDocumentsDataBase.Database);
-            ui->CurrentBaseLabel->setText("Current ducument database : "+GlobalDatabaseList.value(QFileInfo(CurrentDocumentsDataBase.Path).baseName()).Description);
+            SessionManager::instance().CurrentDocumentsDataBase = DTXDB;
+            Database_DocumentTableColumns = SqlFunctions::Get_StringList_From_Query("SELECT name FROM pragma_table_info('Documents')",SessionManager::instance().CurrentDocumentsDataBase.Database);
+            Database_DocTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",SessionManager::instance().CurrentDocumentsDataBase.Database);
+            ui->CurrentBaseLabel->setText("Current ducument database : "+SessionManager::instance().GlobalDatabaseList.value(QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()).Description);
             FilterDocuments(Database_DocumentTableColumns);
         }
         else{
@@ -2540,7 +2508,7 @@ void DataTex::UpdateCurrentDatabase(DTXDatabase DTXDB)
         }
         break;
     }
-    CurrentDTXDataBase = DTXDB;
+    SessionManager::instance().CurrentDTXDataBase = DTXDB;
 }
 
 void DataTex::AddDatabaseToTree(DTXDatabase DTXDB)
@@ -2572,11 +2540,11 @@ void DataTex::DeleteFileFromBase()
     msgbox.setDefaultButton(QMessageBox::Cancel);
     msgbox.setCheckBox(cb);
     if (msgbox.exec() == QMessageBox::Ok) {
-        QSqlQuery deleteQuery(CurrentFilesDataBase.Database);
+        QSqlQuery deleteQuery(SessionManager::instance().CurrentFilesDataBase.Database);
         deleteQuery.exec("PRAGMA foreign_keys = ON");
         deleteQuery.exec(QString("DELETE FROM Database_Files WHERE Id = \"%1\"").arg(DatabaseFileName));
         ShowDataBaseFiles();
-        DBBackUp(CurrentFilesDataBase.Path,datatexpath+QFileInfo(CurrentFilesDataBase.Path).fileName());
+        SessionManager::instance().DBBackUp(SessionManager::instance().CurrentFilesDataBase.Path,SessionManager::instance().datatexpath+QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).fileName());
      if(cb->isChecked()==true){QDesktopServices::openUrl(QUrl("file:///"+QFileInfo(DatabaseFilePath).absolutePath()));}
     }
 }
@@ -2592,7 +2560,7 @@ void DataTex::DeleteDocumentFromBase()
     msgbox.setDefaultButton(QMessageBox::Cancel);
     msgbox.setCheckBox(cb);
     if (msgbox.exec() == QMessageBox::Ok) {
-        QSqlQuery deleteQuery(CurrentDocumentsDataBase.Database);
+        QSqlQuery deleteQuery(SessionManager::instance().CurrentDocumentsDataBase.Database);
         deleteQuery.exec(QString("DELETE FROM Documents WHERE Id = \"%1\"").arg(DocumentFileName));
         ShowDocuments();
      if(cb->isChecked()==true){QDesktopServices::openUrl(QUrl("file:///"+QFileInfo(DocumentFilePath).absolutePath()));}
@@ -2604,14 +2572,14 @@ void DataTex::on_OpenDatabasesTreeWidget_itemClicked(QTreeWidgetItem *item, int 
     if(item->parent()){
      CloseDatabasefile->setEnabled(true);
      QString Database = item->text(2);
-     DTXDatabase DTXDB = GlobalDatabaseList.value(Database);
+     DTXDatabase DTXDB = SessionManager::instance().GlobalDatabaseList.value(Database);
      ConnectDatabase->setEnabled(!DTXDB.IsConnected);
      DisconnectDatabase->setEnabled(DTXDB.IsConnected);
      int row = ui->OpenDatabasesTreeWidget->currentIndex().parent().row();
         if(row==0){
             ui->FilesDatabaseToggle->setChecked(true);
-            UpdateCurrentDatabase(GlobalDatabaseList.value(item->text(2)));
-            DatabaseStructure(CurrentFilesDataBase.Path);
+            UpdateCurrentDatabase(SessionManager::instance().GlobalDatabaseList.value(item->text(2)));
+            DatabaseStructure(SessionManager::instance().CurrentFilesDataBase.Path);
             ShowDataBaseFiles();
             int columns = FilesTable->model()->columnCount();
             for (int i=0;i<columns;i++) {
@@ -2622,20 +2590,18 @@ void DataTex::on_OpenDatabasesTreeWidget_itemClicked(QTreeWidgetItem *item, int 
             FilesTable->setColumnHidden(columns-3,true);
             loadDatabaseFields();
             ui->FilesTagFilter->setChecked(false);
-            delete filesTagLine;
             CreateCustomTagWidget();
             on_ComboCount_currentIndexChanged(0);
             FilesTable->filterHeader()->adjustPositions();
         }
         else if(row==1){
             ui->DocumentsDatabaseToggle->setChecked(true);
-            UpdateCurrentDatabase(GlobalDatabaseList.value(item->text(2)));
-            DatabaseStructure(CurrentDocumentsDataBase.Path);
+            UpdateCurrentDatabase(SessionManager::instance().GlobalDatabaseList.value(item->text(2)));
+            DatabaseStructure(SessionManager::instance().CurrentDocumentsDataBase.Path);
             ShowDocuments();
             loadDatabaseFields();
-            LoadTableHeaders(FilesTable,Database_DocTableFieldNames);
+            SessionManager::instance().LoadTableHeaders(FilesTable,Database_DocTableFieldNames);
 //            ui->DocumentsTagFilter->setChecked(false);
-            delete docsTagLine;
             CreateCustomTagWidget();
             on_ComboCount_currentIndexChanged(1);
             FilesTable->filterHeader()->adjustPositions();
@@ -2645,7 +2611,7 @@ void DataTex::on_OpenDatabasesTreeWidget_itemClicked(QTreeWidgetItem *item, int 
         settings.setValue("SaveNewFileSelections",0);
         settings.endGroup();
 //        QWidget * w = ui->tabWidget->tabBar()->tabButton(0,QTabBar::RightSide);
-//        int count = Optional_Metadata_Ids[CurrentFilesDataBase.BaseName].count();
+//        int count = Optional_Metadata_Ids[SessionManager::instance().CurrentFilesDataBase.BaseName].count();
 //        if(count>0 && !w){
 //            MetadataToolButton();
 //        }
@@ -2676,19 +2642,6 @@ void DataTex::TeXFilesTable_selection_changed()
     file.close();
     ui->FileContent->setText(File_content);
     FileCommands::ShowPdfInViewer(FilePath,FileFromDocumentView);
-}
-
-void DataTex::updateTableView(QTableView * table,QString QueryText,QSqlDatabase Database,QObject * parent)
-{
-    QSqlQueryModel * model = new QSqlQueryModel(parent);
-    QSortFilterProxyModel *proxyModel = new QSortFilterProxyModel(parent);
-    QSqlQuery query(Database);
-    query.exec(QueryText);
-    model->setQuery(query);
-    table->setModel(model);
-    proxyModel->setSourceModel(model);
-    table->show();
-    table->setSortingEnabled(true);
 }
 
 void DataTex::FilterTables_Queries(QStringList list)
@@ -2741,13 +2694,6 @@ void DataTex::FilterBibliographyTable(QStringList list)
     SqlFunctions::FilterBibliographyEntries.remove("ORDER BY b.ROWID");
 }
 
-void DataTex::LoadTableHeaders(QTableView * table,QStringList list)
-{
-    for (int i=0;i<list.count();i++) {
-        table->model()->setHeaderData(i,Qt::Horizontal,list.at(i),Qt::DisplayRole);
-    }
-}
-
 void DataTex::on_DatabaseStructureTreeView_clicked(const QModelIndex &index)
 {
     QModelIndex ix = index;
@@ -2758,12 +2704,12 @@ void DataTex::on_DatabaseStructureTreeView_clicked(const QModelIndex &index)
       depth++;
     }
     int result;
-    QDir dir(CurrentFilesDataBase.Path);
+    QDir dir(SessionManager::instance().CurrentFilesDataBase.Path);
     for(result=0;dir.cdUp();++result){}
     bool isFile = !model->isDir(index);
     QString fileName = QFileInfo(index.data(Qt::DisplayRole).toString()).baseName();
     if(isFile){
-        SelectNewFileInModel(FilesTable,fileName);
+        SessionManager::instance().SelectNewFileInModel(FilesTable,fileName);
     }
 }
 
@@ -2774,16 +2720,16 @@ void DataTex::on_ComboCount_currentIndexChanged(int index)
 
     switch (i) {
     case 0:
-        database = CurrentFilesDataBase.Database;
+        database = SessionManager::instance().CurrentFilesDataBase.Database;
         break;
     case 1:
-        database = CurrentDocumentsDataBase.Database;
+        database = SessionManager::instance().CurrentDocumentsDataBase.Database;
         break;
     case 2:
         // database = Bibliography_Settings;
         break;
     }
-    updateTableView(ui->CountFilesTable,ui->ComboCount->currentData().toString(),database,this);
+    SessionManager::instance().updateTableView(ui->CountFilesTable,ui->ComboCount->currentData().toString(),database,this);
 }
 
 
@@ -2791,7 +2737,7 @@ void DataTex::on_ComboCount_currentIndexChanged(int index)
 void DataTex::setPreamble()
 {
     DTXSettings dtxSettings;
-    CurrentPreamble_Content = dtxSettings.getCurrentPreambleContent(CurrentPreamble);
+    SessionManager::instance().CurrentPreamble_Content = dtxSettings.getCurrentPreambleContent(SessionManager::instance().CurrentPreamble);
 }
 
 void DataTex::Preamble_clicked()
@@ -2856,16 +2802,16 @@ void DataTex::OpenDatabaseInfo(QString filePath,QString FolderName)
         if(Tables.contains("Database_Files")){
             AddDatabaseToTree(DTXDB);
             newDatabase.setDatabaseName(filePath);
-            CurrentFilesDataBase.Database = newDatabase;
-            CurrentFilesDataBase.Path = filePath;
-            GlobalDatabaseList.insert(QFileInfo(filePath).baseName(),DTXDB);
-            CurrentFilesDataBase.Database.open();
+            SessionManager::instance().CurrentFilesDataBase.Database = newDatabase;
+            SessionManager::instance().CurrentFilesDataBase.Path = filePath;
+            SessionManager::instance().GlobalDatabaseList.insert(QFileInfo(filePath).baseName(),DTXDB);
+            SessionManager::instance().CurrentFilesDataBase.Database.open();
             // qDebug()<<"5) db opened";
             SaveData.exec(QString("INSERT INTO Databases (FileName,Name,Path) VALUES (\"%1\",\"%2\",\"%3\")")
                                .arg(baseName,FolderName,filePath));
             SaveData.exec(QString("UPDATE Current_Databases SET Value = \"%1\" WHERE Setting = 'Current_FilesDB'").arg(baseName));
-            QStringList MetadataIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp",CurrentFilesDataBase.Database);
-            QStringList MetadataNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",CurrentFilesDataBase.Database);
+            QStringList MetadataIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp",SessionManager::instance().CurrentFilesDataBase.Database);
+            QStringList MetadataNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",SessionManager::instance().CurrentFilesDataBase.Database);
 
             QSqlQuery add;//(DataTeX_Settings);
             for (int i=0;i<MetadataIds.count();i++) {
@@ -2878,15 +2824,15 @@ void DataTex::OpenDatabaseInfo(QString filePath,QString FolderName)
         else if(Tables.contains("Documents")){
             AddDatabaseToTree(DTXDB);
             newDatabase.setDatabaseName(filePath);
-            DataTex::CurrentDocumentsDataBase.Database = newDatabase;
-            DataTex::CurrentDocumentsDataBase.Path = filePath;
-            GlobalDatabaseList.insert(QFileInfo(filePath).baseName(),DTXDB);
-            DataTex::CurrentDocumentsDataBase.Database.open();
+            SessionManager::instance().CurrentDocumentsDataBase.Database = newDatabase;
+            SessionManager::instance().CurrentDocumentsDataBase.Path = filePath;
+            SessionManager::instance().GlobalDatabaseList.insert(QFileInfo(filePath).baseName(),DTXDB);
+            SessionManager::instance().CurrentDocumentsDataBase.Database.open();
             SaveData.exec(QString("INSERT INTO DataBases (FileName,Name,Path) VALUES (\"%1\",\"%2\",\"%3\")")
                                .arg(baseName,FolderName,filePath));
             SaveData.exec(QString("UPDATE Current_Databases SET Value = \"%1\" WHERE Setting = 'Current_DocumentsDB'").arg(baseName));
-            QStringList MetadataIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp",CurrentDocumentsDataBase.Database);
-            QStringList MetadataNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",CurrentDocumentsDataBase.Database);
+            QStringList MetadataIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp",SessionManager::instance().CurrentDocumentsDataBase.Database);
+            QStringList MetadataNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",SessionManager::instance().CurrentDocumentsDataBase.Database);
             QSqlQuery add;//(DataTeX_Settings);
             for (int i=0;i<MetadataIds.count();i++) {
                 add.exec(QString("INSERT OR IGNORE INTO DocMetadata (Id,Name,Basic) VALUES (\""+MetadataIds.at(i)+"\",\""+MetadataNames.at(i)+"\",0)"));
@@ -2909,14 +2855,14 @@ void DataTex::RemoveCurrentDatabase()
     QString DatabaseType;
     QString DatabaseTable;
     if(ui->stackedWidget->currentIndex()==0){
-        DatabaseName = CurrentFilesDataBase.BaseName;
-        DatabasePath = CurrentFilesDataBase.Path;
+        DatabaseName = SessionManager::instance().CurrentFilesDataBase.BaseName;
+        DatabasePath = SessionManager::instance().CurrentFilesDataBase.Path;
         DatabaseType = "Databases";
         DatabaseTable = "Metadata_per_Database";
     }
     else{
-        DatabaseName = QFileInfo(CurrentDocumentsDataBase.Path).baseName();
-        DatabasePath = CurrentDocumentsDataBase.Path;
+        DatabaseName = QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName();
+        DatabasePath = SessionManager::instance().CurrentDocumentsDataBase.Path;
         DatabaseType = "DataBases";
         DatabaseTable = "DocMetadata_per_Database";
     }
@@ -2957,17 +2903,17 @@ void DataTex::CloneCurrentDocument()
     NotesDocuments * clone = new NotesDocuments(this,temp,CloneModeContentAndMetadata);// Add option for ContentOnly
 //    connect(clone,SIGNAL(createnewdocument(DTXDocument)),this,SLOT(CreateNewDocument(DTXDocument)));
     connect(clone,&NotesDocuments::clonedocument,this,[&](DTXDocument document){
-        QSqlQuery write(GlobalDatabaseList.value(document.Database.Id).Database);
-        write.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(CurrentDocumentsDataBase.Path,QFileInfo(CurrentDocumentsDataBase.Path).baseName()));
+        QSqlQuery write(SessionManager::instance().GlobalDatabaseList.value(document.Database.Id).Database);
+        write.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(SessionManager::instance().CurrentDocumentsDataBase.Path,QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()));
         write.exec(QString("INSERT INTO Files_per_Document (Document_Id,File_Id,Files_Database_Source) SELECT \"%1\",File_Id,Files_Database_Source "
                            "FROM \"%3\".Files_per_Document WHERE Document_Id = '%2'")
-                       .arg(document.Id,DocumentFileName,QFileInfo(CurrentDocumentsDataBase.Path).baseName()));
+                       .arg(document.Id,DocumentFileName,QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()));
         write.exec(QString("INSERT INTO BibEntries_per_Document (Bib_Id,Document_Id) SELECT Bib_Id,\"%1\" "
                            "FROM \"%3\".BibEntries_per_Document WHERE Document_Id = '%2' ")
-                       .arg(document.Id,DocumentFileName,QFileInfo(CurrentDocumentsDataBase.Path).baseName()));
-        write.exec(QString("DETACH DATABASE \"%1\"").arg(QFileInfo(CurrentDocumentsDataBase.Path).baseName()));
+                       .arg(document.Id,DocumentFileName,QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()));
+        write.exec(QString("DETACH DATABASE \"%1\"").arg(QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()));
 //        CreateNewDocument(DTXDocument docInfo);
-        QList<QTreeWidgetItem*> clist = ui->OpenDatabasesTreeWidget->findItems(GlobalDatabaseList.value(document.Database.Id).Description, Qt::MatchContains|Qt::MatchRecursive, 0);
+        QList<QTreeWidgetItem*> clist = ui->OpenDatabasesTreeWidget->findItems(SessionManager::instance().GlobalDatabaseList.value(document.Database.Id).Description, Qt::MatchContains|Qt::MatchRecursive, 0);
         ui->OpenDatabasesTreeWidget->setCurrentItem(clist[0]);
         on_OpenDatabasesTreeWidget_itemClicked(clist[0],0);
         // qDebug()<<clist[0]->text(0);
@@ -2999,13 +2945,13 @@ void DataTex::AddFileToDatabase()
     QString content = FileCommands::ClearMetadataFromContent(text).remove(preamble).trimmed();
     // qDebug()<<content;
     File.close();
-    if(database.isEmpty() || database != CurrentFilesDataBase.BaseName){
+    if(database.isEmpty() || database != SessionManager::instance().CurrentFilesDataBase.BaseName){
         QString message;
         if(database.isEmpty()){
             message = tr("This file doens't have a database source.\n"
                "Do you wish to open it anyway?");
         }
-        else if(database != CurrentFilesDataBase.BaseName){
+        else if(database != SessionManager::instance().CurrentFilesDataBase.BaseName){
             message = tr("This file was created from another database\n"
                          "and some metadada values may differ.\n"
                          "Do you wish to add this file to the current database anyway?");
@@ -3034,7 +2980,7 @@ void DataTex::AddFileToDatabase()
         }
     }
     // qDebug()<<CsvFunctions::ReadCsv(filePath);
-//    else if(database != CurrentFilesDataBase.BaseName){
+//    else if(database != SessionManager::instance().CurrentFilesDataBase.BaseName){
 //        QMessageBox::StandardButton resBtn =
 //        QMessageBox::warning( this,tr("Error"),tr("This file was created from another database\n"
 //                                                  "and some metadada values may differ.\n"
@@ -3159,7 +3105,7 @@ QVariant DataTex::data(const QModelIndex &index, int role) const
 
 void DataTex::on_addBibEntry_clicked()
 {
-    QSqlQuery BibliographyQuery(CurrentFilesDataBase.Database);
+    QSqlQuery BibliographyQuery(SessionManager::instance().CurrentFilesDataBase.Database);
     BibliographyQuery.exec(QString("INSERT INTO Bib_Entries_per_File (Bib_Id,File_Id) VALUES('%1','%2')")
                            .arg(ui->BibEntriesCombo->currentText(),DatabaseFileName));
     // QSqlQuery values(Bibliography_Settings);
@@ -3173,37 +3119,11 @@ void DataTex::on_addBibEntry_clicked()
     //     ui->BibEntriesTable->setItem(i,1 , new QTableWidgetItem(values.value(0).toString()));
     //     ui->BibEntriesTable->setItem(i,2 , new QTableWidgetItem(values.value(1).toString()));
     // }
-    QStringList BibEntriesInFile = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM Bib_Entries_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),CurrentFilesDataBase.Database);
+    QStringList BibEntriesInFile = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM Bib_Entries_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),SessionManager::instance().CurrentFilesDataBase.Database);
     connect(ui->BibEntriesCombo,&QComboBox::currentTextChanged,this,[=](QString text){
         ui->addBibEntry->setEnabled(!BibEntriesInFile.contains(text));
     });
     ui->addBibEntry->setEnabled(false);
-}
-
-void DataTex::StretchColumns(QTableView * Table, float stretchFactor)
-{
-    QFont myFont = Table->horizontalHeader()->font();
-    QFontMetrics fm(myFont);
-    for (int c = 0; c < Table->horizontalHeader()->count(); ++c)
-    {
-        QString str = Table->model()->headerData(c,Qt::Horizontal,Qt::DisplayRole).toString();
-        int width=fm.horizontalAdvance(str)*stretchFactor;
-        Table->setColumnWidth(c,width);
-    }
-    Table->horizontalHeader()->setMinimumSectionSize(100);
-}
-
-void DataTex::StretchColumns(QTreeView * Tree, float stretchFactor)
-{
-    QFont myFont = Tree->header()->font();
-    QFontMetrics fm(myFont);
-    for (int c = 0; c < Tree->model()->columnCount(); ++c)
-    {
-        QString str = Tree->model()->headerData(c,Qt::Horizontal,Qt::DisplayRole).toString();
-        int width=fm.horizontalAdvance(str)*stretchFactor;
-        Tree->setColumnWidth(c,width);
-    }
-    Tree->header()->setMinimumSectionSize(100);
 }
 
 void DataTex::FileClone()
@@ -3216,39 +3136,13 @@ void DataTex::FileClone()
     cloneFile->activateWindow();
 }
 
-bool DataTex::SelectNewFileInModel(QTableView * table,QString newFile)
-{
-    QAbstractItemModel * m = table->model();
-    QModelIndex ix = table->currentIndex();
-    while (table->model()->canFetchMore(ix))
-           table->model()->fetchMore(ix);
-    QModelIndexList matchList = m->match(m->index(0,0), Qt::DisplayRole,
-                               newFile, -1,  Qt::MatchFlags(Qt::MatchContains|Qt::MatchWrap));
-
-    bool fileFound = matchList.count()>=1;
-    if(matchList.count()>=1){
-        table->setCurrentIndex(matchList.first());
-        table->scrollTo(matchList.first());
-    }
-    return fileFound;
-}
-
-void DataTex::StretchColumnsToWidth(QTableView * table)
-{
-    for (int c = 0; c < table->horizontalHeader()->count()-1; ++c)
-    {
-        table->horizontalHeader()->setSectionResizeMode(
-            c, QHeaderView::Stretch);
-    }
-}
-
 void DataTex::NewBibliographyEntry()
 {
     BibEntry * newbib = new BibEntry(this,false,false,QHash<QString,QString>());
     connect(newbib,&BibEntry::accepted,this,[=](){
         QString id = newbib->getBibValues()["Citation_Key"];
         ShowBibliography();
-        SelectNewFileInModel(FilesTable,id);
+        SessionManager::instance().SelectNewFileInModel(FilesTable,id);
     });
     newbib->show();
     newbib->activateWindow();
@@ -3281,7 +3175,7 @@ void DataTex::DeleteBibliographyEntry()
         // QSqlQuery deleteQuery(Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Bibliography WHERE Citation_Key = '%1'").arg(CitationKey));
-        QSqlQuery deleteCitation(CurrentFilesDataBase.Database);
+        QSqlQuery deleteCitation(SessionManager::instance().CurrentFilesDataBase.Database);
         deleteCitation.exec(QString("DELETE FROM Bib_Entries_per_File WHERE Bib_Id = '%1'").arg(CitationKey));
         ShowBibliography();
     }
@@ -3377,20 +3271,11 @@ void DataTex::OpenAuthorsEditors()
     authors->activateWindow();
 }
 
-QStringList DataTex::GetListWidgetItems(QListWidget * list)
-{
-    QStringList items;
-    for(int i=0;i<list->count();i++){
-        items.append(list->item(i)->text());
-    }
-    return items;
-}
-
 void DataTex::on_NewBibEntry_CurrentFile_clicked()
 {
     BibEntry * newEntryforFile = new BibEntry(this,false,false,QHash<QString,QString>());
     connect(newEntryforFile,&BibEntry::accepted,this,[=](){
-        QSqlQuery BibliographyQuery(CurrentFilesDataBase.Database);
+        QSqlQuery BibliographyQuery(SessionManager::instance().CurrentFilesDataBase.Database);
         QString citationKey = newEntryforFile->getBibValues()["Citation_Key"];
         BibliographyQuery.exec(QString("INSERT INTO Bib_Entries_per_File (Bib_Id,File_Id) VALUES('%1','%2')")
                                .arg(citationKey,DatabaseFileName));
@@ -3406,7 +3291,7 @@ void DataTex::on_NewBibEntry_CurrentFile_clicked()
         //     ui->BibEntriesTable->setItem(i,1 , new QTableWidgetItem(values.value(0).toString()));
         //     ui->BibEntriesTable->setItem(i,2 , new QTableWidgetItem(values.value(1).toString()));
         // }
-        QStringList BibEntriesInFile = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM Bib_Entries_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),CurrentFilesDataBase.Database);
+        QStringList BibEntriesInFile = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM Bib_Entries_per_File WHERE File_Id = '%1'").arg(DatabaseFileName),SessionManager::instance().CurrentFilesDataBase.Database);
         connect(ui->BibEntriesCombo,&QComboBox::currentTextChanged,this,[=](QString text){
             ui->addBibEntry->setEnabled(!BibEntriesInFile.contains(text));
         });
@@ -3419,7 +3304,7 @@ void DataTex::on_NewBibEntry_CurrentFile_clicked()
 void DataTex::on_addDocBibEntry_clicked()
 {
     QString newEntry = ui->DocBibEntriesCombo->currentText();
-    QSqlQuery BibliographyQuery(CurrentDocumentsDataBase.Database);
+    QSqlQuery BibliographyQuery(SessionManager::instance().CurrentDocumentsDataBase.Database);
     BibliographyQuery.exec(QString("INSERT INTO BibEntries_per_Document (Bib_Id,Document_Id) VALUES('%1','%2')")
                            .arg(newEntry,DocumentFileName));
 
@@ -3437,7 +3322,7 @@ void DataTex::on_addDocBibEntry_clicked()
     ui->BibPerFileTree->topLevelItem(1)->addChild(item);
     item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable);
     item->setCheckState(0,Qt::Checked);
-//    foreach(QSqlDatabase database,GlobalDatabaseList.values()){
+//    foreach(QSqlDatabase database,SessionManager::instance().GlobalDatabaseList.values()){
 //        QSqlQuery FilesPerEntry(database);
 //        FilesPerEntry.exec(QString("SELECT File_Id,Path "
 //                                   "FROM Bib_Entries_per_File bpf "
@@ -3452,7 +3337,7 @@ void DataTex::on_addDocBibEntry_clicked()
 //        }
 //    }
 
-    QStringList BibEntriesInDocument = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM BibEntries_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName),CurrentDocumentsDataBase.Database);
+    QStringList BibEntriesInDocument = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM BibEntries_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName),SessionManager::instance().CurrentDocumentsDataBase.Database);
     connect(ui->DocBibEntriesCombo,&QComboBox::currentTextChanged,this,[=](QString text){
         ui->addDocBibEntry->setEnabled(!BibEntriesInDocument.contains(text));
     });
@@ -3463,7 +3348,7 @@ void DataTex::on_NewBibEntry_CurrentDocument_clicked()
 {
     BibEntry * newEntryforDocument = new BibEntry(this,false,false,QHash<QString,QString>());
     connect(newEntryforDocument,&BibEntry::accepted,this,[=](){
-        QSqlQuery BibliographyQuery(CurrentDocumentsDataBase.Database);
+        QSqlQuery BibliographyQuery(SessionManager::instance().CurrentDocumentsDataBase.Database);
         QString citationKey = newEntryforDocument->getBibValues()["Citation_Key"];
         QString DocType = newEntryforDocument->getBibValues()["Document_Type"];
         BibliographyQuery.exec(QString("INSERT INTO BibEntries_per_Document (Bib_Id,Document_Id) VALUES('%1','%2')")
@@ -3476,7 +3361,7 @@ void DataTex::on_NewBibEntry_CurrentDocument_clicked()
         ui->BibPerFileTree->topLevelItem(1)->addChild(item);
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable);
         item->setCheckState(0,Qt::Checked);
-        QStringList BibEntriesInDocument = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM BibEntries_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName),CurrentDocumentsDataBase.Database);
+        QStringList BibEntriesInDocument = SqlFunctions::Get_StringList_From_Query(QString("SELECT Bib_Id FROM BibEntries_per_Document WHERE Document_Id = '%1'").arg(DocumentFileName),SessionManager::instance().CurrentDocumentsDataBase.Database);
         connect(ui->DocBibEntriesCombo,&QComboBox::currentTextChanged,this,[=](QString text){
             ui->addDocBibEntry->setEnabled(!BibEntriesInDocument.contains(text));
         });
@@ -3499,7 +3384,16 @@ int DataTex::TreeItemIndex(QModelIndex index)
 
 void DataTex::CreateCustomTagWidget()
 {
-    filesTagLine = new TagsFilterWidget(this,SqlFunctions::Get_StringList_From_Query("SELECT * FROM CustomTags",DataTex::CurrentFilesDataBase.Database));
+    if(filesTagLine){
+        delete filesTagLine;
+        filesTagLine = nullptr;
+    }
+    if(docsTagLine){
+        delete docsTagLine;
+        docsTagLine = nullptr;
+    }
+
+    filesTagLine = new TagsFilterWidget(this,SqlFunctions::Get_StringList_From_Query("SELECT * FROM CustomTags",SessionManager::instance().CurrentFilesDataBase.Database));
     filesTagLine->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Fixed);
     ui->verticalLayout_20->addWidget(filesTagLine);
     connect(filesTagLine,&TagsFilterWidget::SelectedTags,this,[=](QStringList list){
@@ -3512,7 +3406,7 @@ void DataTex::CreateCustomTagWidget()
     });
     ui->FilesTagFilter->setChecked(false);
 
-    docsTagLine = new TagsFilterWidget(this,SqlFunctions::Get_StringList_From_Query("SELECT * FROM CustomTags",DataTex::CurrentDocumentsDataBase.Database));
+    docsTagLine = new TagsFilterWidget(this,SqlFunctions::Get_StringList_From_Query("SELECT * FROM CustomTags",SessionManager::instance().CurrentDocumentsDataBase.Database));
     docsTagLine->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Fixed);
     docsTagLine->setVisible(false);
 }
@@ -3542,7 +3436,7 @@ void DataTex::LoadCountCombo(int index)
         ui->ComboCount->addItem(tr("Publisher"),QVariant(SqlFunctions::CountBib_by_Publisher));
         break;
     }
-    StretchColumnsToWidth(ui->CountFilesTable);
+    SessionManager::instance().StretchColumnsToWidth(ui->CountFilesTable);
 }
 void DataTex::mousePressEvent(QMouseEvent* event)
 {
@@ -3636,17 +3530,17 @@ void DataTex::readSettings()
 {
     QSettings settings;
 //    settings.beginGroup("LaTeX_Settings");
-//    PdfLatex_Command = settings.value("Pdflatex_Command").toString();
-//    XeLatex_Command = settings.value("Xelatex_Command").toString();
-//    Latex_Command = settings.value("Latex_Command").toString();
-//    LuaLatex_Command = settings.value("Lualatex_Command").toString();
-//    Bibtex_Command = settings.value("Bibtex_Command").toString();
-//    Pythontex_Command = settings.value("Pythontex_Command").toString();
-//    Asymptote_Command = settings.value("Asymptote_Command").toString();
-//    CurrentPreamble = settings.value("Current_Preamble").toString();
+//    SessionManager::instance().PdfLatex_Command = settings.value("Pdflatex_Command").toString();
+//    SessionManager::instance().XeLatex_Command = settings.value("Xelatex_Command").toString();
+//    SessionManager::instance().Latex_Command = settings.value("SessionManager::instance().Latex_Command").toString();
+//    SessionManager::instance().LuaLatex_Command = settings.value("Lualatex_Command").toString();
+//    SessionManager::instance().Bibtex_Command = settings.value("SessionManager::instance().Bibtex_Command").toString();
+//    SessionManager::instance().Pythontex_Command = settings.value("SessionManager::instance().Pythontex_Command").toString();
+//    SessionManager::instance().Asymptote_Command = settings.value("SessionManager::instance().Asymptote_Command").toString();
+//    SessionManager::instance().CurrentPreamble = settings.value("Current_Preamble").toString();
 //    settings.endGroup();
     settings.beginGroup("Application_Settings");
-    currentlanguage = settings.value("Language").toString();
+    SessionManager::instance().currentlanguage = settings.value("Language").toString();
     filesSorting = settings.value("SortFiles").toBool();
     docsSorting = settings.value("SortDocuments").toBool();
     bibSorting = settings.value("SortBibliography").toBool();
@@ -3657,33 +3551,21 @@ void DataTex::writeSettings()
 {
     QSettings settings;
 //    settings.beginGroup("LaTeX_Settings");
-//    settings.setValue("Pdflatex_Command", PdfLatex_Command);
-//    settings.setValue("Xelatex_Command", XeLatex_Command);
-//    settings.setValue("Latex_Command", Latex_Command);
-//    settings.setValue("Lualatex_Command", LuaLatex_Command);
-//    settings.setValue("Bibtex_Command", Bibtex_Command);
-//    settings.setValue("Pythontex_Command", Pythontex_Command);
-//    settings.setValue("Asymptote_Command", Asymptote_Command);
-//    settings.setValue("Current_Preamble", CurrentPreamble);
+//    settings.setValue("Pdflatex_Command", SessionManager::instance().PdfLatex_Command);
+//    settings.setValue("Xelatex_Command", SessionManager::instance().XeLatex_Command);
+//    settings.setValue("SessionManager::instance().Latex_Command", SessionManager::instance().Latex_Command);
+//    settings.setValue("Lualatex_Command", SessionManager::instance().LuaLatex_Command);
+//    settings.setValue("SessionManager::instance().Bibtex_Command", SessionManager::instance().Bibtex_Command);
+//    settings.setValue("SessionManager::instance().Pythontex_Command", SessionManager::instance().Pythontex_Command);
+//    settings.setValue("SessionManager::instance().Asymptote_Command", SessionManager::instance().Asymptote_Command);
+//    settings.setValue("Current_Preamble", SessionManager::instance().CurrentPreamble);
 //    settings.endGroup();
     settings.beginGroup("Application_Settings");
     settings.setValue("SortFiles", filesSorting);
     settings.setValue("SortDocuments", docsSorting);
     settings.setValue("SortBibliography", bibSorting);
-    settings.setValue("datatexpath", datatexpath);
+    settings.setValue("datatexpath", SessionManager::instance().datatexpath);
     settings.endGroup();
-}
-
-void DataTex::DBBackUp(QString database, QString dest_path)
-{
-    QFile file(database);
-//    QProcess::execute("chmod",{"777",datatexpath});
-    if (QFile::exists(dest_path))
-    {
-        QFile::remove(dest_path);
-    }
-    file.copy(dest_path);
-//    QProcess::execute("chmod",{"555",datatexpath});
 }
 
 void DataTex::RestoreDB(int dbtype,QSqlDatabase database)
@@ -3706,7 +3588,7 @@ void DataTex::RestoreDB(int dbtype,QSqlDatabase database)
         QString CurrentBuildCommand = files.value(2).toString();
         QString Preamble = files.value(3).toString();
         DTXSettings dtxSettings;
-        CurrentPreamble_Content = dtxSettings.getCurrentPreambleContent(Preamble);
+        SessionManager::instance().CurrentPreamble_Content = dtxSettings.getCurrentPreambleContent(Preamble);
         QDir dir(QFileInfo(filePath).absolutePath());
         if (!dir.exists())
             dir.mkpath(".");
@@ -3718,7 +3600,7 @@ void DataTex::RestoreDB(int dbtype,QSqlDatabase database)
         texFile.close();
 //        if(PdfSelected){
 //            FileCommands::CreateTexFile(file,0,"");
-//            FileCommands::BuildDocument(DataTex::DTXBuildCommands[CurrentBuildCommand],file
+//            FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[CurrentBuildCommand],file
 //                                   ,DataTex::LatexCommandsArguments[CurrentBuildCommand],".tex");
 //            FileCommands::ClearOldFiles(file);
 //        }
@@ -3764,7 +3646,7 @@ void DataTex::encrFileDB_Dialog(QList<DTXDatabase> databases)
                 QList<QTreeWidgetItem*> clist = ui->OpenDatabasesTreeWidget->findItems(db.BaseName, Qt::MatchContains|Qt::MatchRecursive, 2);
                 ui->OpenDatabasesTreeWidget->setCurrentItem(clist[0]);
                 on_OpenDatabasesTreeWidget_itemClicked(clist[0],0);
-                UpdateCurrentDatabase(GlobalDatabaseList.value(db.BaseName));
+                UpdateCurrentDatabase(SessionManager::instance().GlobalDatabaseList.value(db.BaseName));
                 switch (db.Type) {
                 case DTXDatabaseType::FilesDB:
                     ShowDataBaseFiles();
@@ -3821,24 +3703,6 @@ void DataTex::encrFileDB_Dialog(QList<DTXDatabase> databases)
     d->show();
 }
 
-void DataTex::runQuery_Root(QString queryText,QSqlDatabase database)
-{
-    /* Make dir writable for DataTex_Settings
-     * QProcess::execute("chmod",{"777",datatexpath});
-     * run query for DT and Bib databases
-     * QProcess::execute("chmod",{"555",datatexpath});
-     *  and back readable again */
-//    QProcess::execute("chmod",{"777",datatexpath});
-    QSqlQuery query(database);
-    query.exec(queryText);
-//    QProcess::execute("chmod",{"555",datatexpath});
-}
-
-QString DataTex::getDataTexPath()
-{
-    return datatexpath;
-}
-
 void DataTex::initialize(QString dtexFile)
 {
 //    QString dtexFile = QCoreApplication::arguments().last();
@@ -3846,14 +3710,14 @@ void DataTex::initialize(QString dtexFile)
         DTXDatabaseInfo DBInfo = FileCommands::GetDatabaseTypeFromDTexFile(dtexFile);
         QString texFile = dtexFile;
         texFile.replace(".dtex",".tex");
-        bool databaseExists = (GlobalDatabaseList.contains(DBInfo.Id));
+        bool databaseExists = (SessionManager::instance().GlobalDatabaseList.contains(DBInfo.Id));
         if(databaseExists){
             QList<QTreeWidgetItem*> clist = ui->OpenDatabasesTreeWidget->findItems(DBInfo.Name, Qt::MatchContains|Qt::MatchRecursive, 0);
             ui->OpenDatabasesTreeWidget->setCurrentItem(clist[0]);
             on_OpenDatabasesTreeWidget_itemClicked(clist[0],0);
             if(DBInfo.Type == DTXDatabaseType::FilesDB){
                 DTXFile *fileInfo = new DTXFile(dtexFile);
-                if(SelectNewFileInModel(FilesTable,fileInfo->Id)){
+                if(SessionManager::instance().SelectNewFileInModel(FilesTable,fileInfo->Id)){
                     return;
                 }
                 else{
@@ -3867,7 +3731,7 @@ void DataTex::initialize(QString dtexFile)
             }
             else if(DBInfo.Type == DTXDatabaseType::DocumentsDB){
                 DTXDocument *docInfo = new DTXDocument(dtexFile);
-                if(SelectNewFileInModel(FilesTable,docInfo->Id)){
+                if(SessionManager::instance().SelectNewFileInModel(FilesTable,docInfo->Id)){
                     return;
                 }
                 else{
@@ -3969,15 +3833,15 @@ void DataTex::on_MinimizeButton_clicked()
 void DataTex::SetDatabaseConnected(QTreeWidgetItem * item)
 {
     QString db = item->text(2);
-    if(!GlobalDatabaseList.value(db).Encrypt){
-        GlobalDatabaseList[db].Database.open();
-        GlobalDatabaseList[db].IsConnected = true;
+    if(!SessionManager::instance().GlobalDatabaseList.value(db).Encrypt){
+        SessionManager::instance().GlobalDatabaseList[db].Database.open();
+        SessionManager::instance().GlobalDatabaseList[db].IsConnected = true;
         item->setIcon(0,QIcon::fromTheme("ConnectDB"));
         ui->OpenDatabasesTreeWidget->setCurrentItem(item);
         on_OpenDatabasesTreeWidget_itemClicked(item,0);
         ConnectDatabase->setEnabled(false);
         DisconnectDatabase->setEnabled(true);
-        QFile file(QString(datatexpath+"Databases/"+db+".json"));
+        QFile file(QString(SessionManager::instance().datatexpath+"Databases/"+db+".json"));
         file.open(QFile::ReadWrite | QFile::Text);
         QJsonDocument doc(QJsonDocument::fromJson(file.readAll()));
         QJsonObject dbObject(doc.object());
@@ -3992,14 +3856,14 @@ void DataTex::SetDatabaseConnected(QTreeWidgetItem * item)
 void DataTex::SetDatabaseDisconnected(QTreeWidgetItem *item)
 {
     QString db = item->text(2);
-    GlobalDatabaseList[db].Database.close();
-    GlobalDatabaseList[db].IsConnected = false;
+    SessionManager::instance().GlobalDatabaseList[db].Database.close();
+    SessionManager::instance().GlobalDatabaseList[db].IsConnected = false;
     item->setIcon(0,QIcon::fromTheme("DisconnectDB"));
     ui->OpenDatabasesTreeWidget->setCurrentItem(item);
     on_OpenDatabasesTreeWidget_itemClicked(item,0);
     ConnectDatabase->setEnabled(true);
     DisconnectDatabase->setEnabled(false);
-    QFile file(QString(datatexpath+"Databases/"+db+".json"));
+    QFile file(QString(SessionManager::instance().datatexpath+"Databases/"+db+".json"));
     file.open(QFile::ReadWrite | QFile::Text);
     QJsonDocument doc(QJsonDocument::fromJson(file.readAll()));
     QJsonObject dbObject(doc.object());
@@ -4013,7 +3877,7 @@ void DataTex::SetDatabaseDisconnected(QTreeWidgetItem *item)
 void DataTex::AreAllDBConnected()
 {
     int DBConnected = 0;
-    for(DTXDatabase DTXDB : GlobalDatabaseList.values()){
+    for(DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList.values()){
         if(DTXDB.IsConnected){
             DBConnected++;
         }

--- a/datatex.h
+++ b/datatex.h
@@ -40,6 +40,7 @@
 #include "tablebuilder.h"
 #include "databasecreator.h"
 #include "filecommands.h"
+#include "sessionmanager.h"
 
 #include <QtPdf>
 //#include <QtPdfWidgets>
@@ -85,49 +86,6 @@ class DataTex : public QMainWindow
 public:
     DataTex(QWidget *parent = nullptr);
     ~DataTex();
-
-    // static QSqlDatabase DataTeX_Settings;
-    // static QSqlDatabase Bibliography_Settings;
-
-
-    static DTXDatabase CurrentFilesDataBase;
-    static DTXDatabase CurrentDocumentsDataBase;
-    static DTXDatabase CurrentBibliographyDataBase;
-    static DTXDatabase CurrentTablesDataBase;
-    static DTXDatabase CurrentFiguresDataBase;
-    static DTXDatabase CurrentCommandsDataBase;
-    static DTXDatabase CurrentPreamblesDataBase;
-    static DTXDatabase CurrentPackagesDataBase;
-    static DTXDatabase CurrentClassesDataBase;
-    static DTXDatabase CurrentDTXDataBase;
-
-    static QHash<QString,DTXDatabase> GlobalDatabaseList;
-
-    static QString CurrentPreamble;
-    static QString CurrentPreamble_Content;
-    static QStringList DocTypesIds;
-    static QStringList DocTypesNames;
-    static QString PdfLatex_Command;
-    static QString Latex_Command;
-    static QString XeLatex_Command;
-    static QString LuaLatex_Command;
-    static QString Pythontex_Command;
-    static QString Bibtex_Command;
-    static QString Asymptote_Command;
-    static QString RunCommand;
-    static QHash<QString,QString> BuildCommands;
-    static QHash<int,DTXBuildCommand> DTXBuildCommands;
-//    static QHash<QString,QStringList> LatexCommandsArguments;
-    static QString GlobalSaveLocation;
-    static QString TexLivePath;
-//    static QHash<QString,QStringList> Optional_Metadata_Ids;
-//    static QHash<QString,QStringList> Optional_Metadata_Names;
-    static QHash<QString,QStringList> Optional_DocMetadata_Ids;
-    static QHash<QString,QStringList> Optional_DocMetadata_Names;
-    static QTranslator translator;
-    static QString currentlanguage;
-    static QString datatexpath;
-    static QStringList SVG_IconPaths;
 
 private:
     Ui::DataTex *ui;
@@ -532,23 +490,13 @@ protected:
 
 public slots:
 //    static void BuildChain(QStringList ListOfCommands);
-    static void updateTableView(QTableView * table, QString QueryText, QSqlDatabase Database, QObject *parent);
     static void FilterTables_Queries(QStringList list);
     static void FilterDocuments(QStringList list);
     static void FilterBibliographyTable(QStringList list);
-    static void LoadTableHeaders(QTableView * table, QStringList list);
     static void FunctionInProgress();
-    static void StretchColumns(QTableView * Table,float stretchFactor);
-    static void StretchColumns(QTreeView * Tree,float stretchFactor);
-    static void StretchColumnsToWidth(QTableView *table);
-    static QStringList GetListWidgetItems(QListWidget * list);
 //    static QHash<QString,QString> ReadRow(QTableView * table);
-    static void DBBackUp(QString database,QString dest_path);
-    static void runQuery_Root(QString queryText, QSqlDatabase database);
-    static QString getDataTexPath();
     void initialize(QString dtexFile);
     void onOtherInstanceMessage(const QString &file);
-    static bool SelectNewFileInModel(QTableView *table, QString newFile);
 
 signals:
     void dataChanged(QModelIndex index, QModelIndex index2);

--- a/datatex/adddatabasefield.cpp
+++ b/datatex/adddatabasefield.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "adddatabasefield.h"
 #include "ui_adddatabasefield.h"
 #include <QtCore>
@@ -25,7 +26,7 @@ AddDatabaseField::AddDatabaseField(QWidget *parent,QString Info,bool isSubSectio
     QRegularExpressionValidator * validator = new QRegularExpressionValidator( pk, this );
     ui->CodeLine->setValidator(validator);
     if(IsSubSection){
-        QSqlQuery GetSubSecIds(DataTex::CurrentFilesDataBase.Database);
+        QSqlQuery GetSubSecIds(SessionManager::instance().CurrentFilesDataBase.Database);
         GetSubSecIds.exec("SELECT * FROM Exercise_Types WHERE Id <> \"-\"");
         while(GetSubSecIds.next()){
             MapSubSecIds.insert(GetSubSecIds.value(0).toString(),GetSubSecIds.value(1).toString());
@@ -38,7 +39,7 @@ AddDatabaseField::AddDatabaseField(QWidget *parent,QString Info,bool isSubSectio
         NameCompleter->setCaseSensitivity(Qt::CaseInsensitive);
         ui->NameLine->setCompleter(NameCompleter);
     }
-    QStringList SubSections_Names = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Exercise_Types WHERE Id <> \"-\"",DataTex::CurrentFilesDataBase.Database);
+    QStringList SubSections_Names = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Exercise_Types WHERE Id <> \"-\"",SessionManager::instance().CurrentFilesDataBase.Database);
     connect(ui->CodeLine,&QLineEdit::textChanged,this,[&](QString text){
         if(text.length()>7){
             ui->warning->setText(tr("Use short primary keys\n(<8 characters) for short file names."));

--- a/datatex/addfiletoeditor.cpp
+++ b/datatex/addfiletoeditor.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "addfiletoeditor.h"
 #include "ui_addfiletoeditor.h"
 
@@ -9,13 +10,13 @@ AddFileToEditor::AddFileToEditor(QWidget *parent,QString currentTexFile, QString
     CurrentFile = currentTexFile;
     CurrentBuildCommand = BuildCommand;
     RandomFilesToKeep = 0;
-    for (DTXDatabase DTXDB : DataTex::GlobalDatabaseList) {
+    for (DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList) {
         if(DTXDB.Type == DTXDatabaseType::FilesDB){
             ui->FilesDatabasesCombo->addItem(DTXDB.Description,QVariant::fromValue(DTXDB));
         }
     }
-    currentbase = DataTex::CurrentFilesDataBase.Database;
-    ui->FilesDatabasesCombo->setCurrentText(DataTex::CurrentFilesDataBase.Description);
+    currentbase = SessionManager::instance().CurrentFilesDataBase.Database;
+    ui->FilesDatabasesCombo->setCurrentText(SessionManager::instance().CurrentFilesDataBase.Description);
     ui->removeButton->setEnabled(false);
     ui->addEverything->setEnabled(false);
     setWindowTitle(tr("Insert files to document : ")+QFileInfo(CurrentFile).fileName());
@@ -32,11 +33,11 @@ AddFileToEditor::AddFileToEditor(QWidget *parent,QString currentTexFile, QString
     FilesTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     FilesTable->horizontalHeader()->setSectionsClickable(true);
     FilesTable->setAlternatingRowColors(true);
-    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp WHERE",DataTex::CurrentFilesDataBase.Database);
-    Database_FileTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE",DataTex::CurrentFilesDataBase.Database);
-    LoadDatabaseFiles(DataTex::CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
+    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp WHERE",SessionManager::instance().CurrentFilesDataBase.Database);
+    Database_FileTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE",SessionManager::instance().CurrentFilesDataBase.Database);
+    LoadDatabaseFiles(SessionManager::instance().CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
     ui->numOfFilesSpin->setMaximum(CountModelRows());
-    DataTex::StretchColumns(FilesTable,1.5);
+    SessionManager::instance().StretchColumns(FilesTable,1.5);
     ui->FilesDatabasesCombo->setEnabled(false);
     QString FileContent;
     QFile file(CurrentFile);
@@ -197,7 +198,7 @@ void AddFileToEditor::LoadDatabaseFiles(QSqlDatabase database,QString query)
     FilesTable->generateFilters(columns,false);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this, &AddFileToEditor::FilesTable_selectionchanged);
     connect(FilesTable->filterHeader(), &FilterTableHeader::filterValues, this, &AddFileToEditor::updateFilter);
-    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
 }
 
 void AddFileToEditor::updateFilter(QStringList values)
@@ -205,11 +206,11 @@ void AddFileToEditor::updateFilter(QStringList values)
     SqlFunctions::FilterTable(Database_FileTableFields,values);
     int columns = Database_FileTableFields.count();
     FilesTable->setColumnHidden(columns,true);
-    DataTex::updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,currentbase,this);
+    SessionManager::instance().updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,currentbase,this);
     FilesTable->filterTable(SqlFunctions::FilesTable_UpdateQuery,currentbase,filesSorting);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &AddFileToEditor::FilesTable_selectionchanged);
-    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
     ui->numOfFilesSpin->setMaximum(CountModelRows());
 }
 
@@ -228,7 +229,7 @@ void AddFileToEditor::FilesTable_selectionchanged()
     QString pdffile = file.replace(".tex",".pdf");
     if(!QFileInfo::exists(pdffile)){
 //        FileCommands::CreateTexFile(PreviewFile,0,""/*preamble*/);
-//        FileCommands::BuildDocument(DataTex::DTXBuildCommands[buildCommand],PreviewFile,DataTex::LatexCommandsArguments[buildCommand],".tex");
+//        FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[buildCommand],PreviewFile,SessionManager::instance().LatexCommandsArguments[buildCommand],".tex");
 //        FileCommands::ClearOldFiles(PreviewFile);
         //Need to add a 'preamble' variable in CreateTexFile command
     }
@@ -313,12 +314,12 @@ void AddFileToEditor::on_Okbutton_accepted()
     for (int i = 0;i<ExercisesInsideDocument.count();i++ ) {
         valuesQuery.append("(\""+QFileInfo(CurrentFile).baseName()+"\",\""+ExercisesInsideDocument[i]+"\",\""+DatabasesInsideDocument[i]+"\")");
     }
-    QSqlQuery writeExercisesPerDatabase(DataTex::CurrentDocumentsDataBase.Database);
+    QSqlQuery writeExercisesPerDatabase(SessionManager::instance().CurrentDocumentsDataBase.Database);
     writeExercisesPerDatabase.exec("INSERT OR IGNORE INTO Files_per_Document (Document_Id,File_Id,Files_Database_Source) VALUES "+valuesQuery.join(","));
     writeExercisesPerDatabase.exec(QString("DELETE FROM Files_per_Document WHERE Document_Id = \"%1\" AND File_Id NOT IN (\""+ExercisesInsideDocument.join("\",\"")+"\")").arg(CurrentFile));
     QSettings settings;
     QString datatexpath = settings.value("Application_Settings/datatexpath").toString();
-    DataTex::DBBackUp(DataTex::CurrentDocumentsDataBase.Path,datatexpath+QFileInfo(DataTex::CurrentDocumentsDataBase.Path).fileName());
+    SessionManager::instance().DBBackUp(SessionManager::instance().CurrentDocumentsDataBase.Path,datatexpath+QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).fileName());
     accept();
 }
 
@@ -326,7 +327,7 @@ void AddFileToEditor::onRebuild()
 {
     ui->DocumentContent->toolBar->Save->trigger();
     FileCommands::CreateTexFile(CurrentFile,0,"");
-    FileCommands::BuildDocument(DataTex::DTXBuildCommands.value((int)CompileEngine::PdfLaTeX),CurrentFile);//CurrentBuildCommand
+    FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands.value((int)CompileEngine::PdfLaTeX),CurrentFile);//CurrentBuildCommand
     FileCommands::ClearOldFiles(CurrentFile);
     FileCommands::ShowPdfInViewer(CurrentFile,DocView);
 }
@@ -340,7 +341,7 @@ void AddFileToEditor::on_checkBox_clicked(bool checked)
     }
     else {
         ui->FilesDatabasesCombo->setEnabled(checked);
-        LoadDatabaseFiles(DataTex::CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
+        LoadDatabaseFiles(SessionManager::instance().CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
         FilesTable->filterHeader()->adjustPositions();
     }
 }
@@ -444,22 +445,22 @@ void AddFileToEditor::SelectedFilesInDocument()
 //    DatabasesInsideDocument.removeDuplicates();
 //    QStringList Databases =
 //            SqlFunctions::Get_StringList_From_Query(QString("SELECT Path FROM Databases WHERE FileName IN (\"%1\")").arg(DatabasesInsideDocument.join("\",\""))
-//            ,DataTex::DataTeX_Settings);
+//            ,SessionManager::instance().DataTeX_Settings);
 //    QString files = "(\""+ExercisesInsideDocument.join("\",\"")+"\")";
 //    QSqlQueryModel * Files = new QSqlQueryModel(this);
-//    QStringList datalist;// = {SqlFunctions::ShowFilesInADocument.arg(files,QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName())};
+//    QStringList datalist;// = {SqlFunctions::ShowFilesInADocument.arg(files,QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName())};
 //    QString query;
-//    QSqlQuery FilesQuery(DataTex::CurrentFilesDataBase.Database);
+//    QSqlQuery FilesQuery(SessionManager::instance().CurrentFilesDataBase.Database);
 ////    for (int i=0;i<DatabasesInsideDocument.count();i++) {
-////        if(DatabasesInsideDocument.at(i)!=QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName()) {
+////        if(DatabasesInsideDocument.at(i)!=QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName()) {
 ////            FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(Databases.at(i),DatabasesInsideDocument[i]));
 ////            datalist.append(SqlFunctions::ShowFilesInADocument_DifferentDatabase.arg(files,DatabasesInsideDocument[i]));
 ////        }
 ////    }
 //    for (int i=0;i<DatabasesInsideDocument.count();i++) {
-//        QString name = (Databases.at(i)!=DataTex::CurrentFilesDataBase.Path) ? QFileInfo(Databases.at(i)).baseName() : "main" ;
+//        QString name = (Databases.at(i)!=SessionManager::instance().CurrentFilesDataBase.Path) ? QFileInfo(Databases.at(i)).baseName() : "main" ;
 //        datalist.append(SqlFunctions::ShowFilesInADocument.arg(files,DatabasesInsideDocument[i],name));
-//        if(Databases.at(i)!=DataTex::CurrentFilesDataBase.Path) {
+//        if(Databases.at(i)!=SessionManager::instance().CurrentFilesDataBase.Path) {
 //            FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(Databases.at(i),QFileInfo(Databases.at(i)).baseName()));
 //        }
 //    }
@@ -471,7 +472,7 @@ void AddFileToEditor::SelectedFilesInDocument()
 //    ui->filesSelected->show();
 //    connect(ui->filesSelected->selectionModel(), &QItemSelectionModel::selectionChanged,
 //            this, &AddFileToEditor::filesSelected_SelectionChanged);
-//    DataTex::StretchColumns(ui->filesSelected,1.5);
+//    SessionManager::instance().StretchColumns(ui->filesSelected,1.5);
 
     QStringList FilesInsideDocument;
     QStringList DatabasesInsideDocument;
@@ -500,13 +501,13 @@ void AddFileToEditor::SelectedFilesInDocument()
     DatabasesInsideDocument.removeDuplicates();
     QString files = "(\""+FilesInsideDocument.join("\",\"")+"\")";
     QSqlQueryModel * FilesModel = new QSqlQueryModel(this);
-    QStringList DataQueries;// = {SqlFunctions::ShowFilesInADocument.arg(files,QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName())};
-    QSqlQuery FilesQuery(DataTex::CurrentFilesDataBase.Database);
+    QStringList DataQueries;// = {SqlFunctions::ShowFilesInADocument.arg(files,QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName())};
+    QSqlQuery FilesQuery(SessionManager::instance().CurrentFilesDataBase.Database);
     for (QString databaseId : DatabasesInsideDocument) {
-        DTXDatabase DTXDB = DataTex::GlobalDatabaseList.value(databaseId);
-        QString name = (DTXDB.Path!=DataTex::CurrentFilesDataBase.Path) ? DTXDB.BaseName : "main" ;
+        DTXDatabase DTXDB = SessionManager::instance().GlobalDatabaseList.value(databaseId);
+        QString name = (DTXDB.Path!=SessionManager::instance().CurrentFilesDataBase.Path) ? DTXDB.BaseName : "main" ;
         DataQueries.append(SqlFunctions::ShowFilesInADocument.arg(files,DTXDB.BaseName,name));
-        if(DTXDB.Path!=DataTex::CurrentFilesDataBase.Path) {
+        if(DTXDB.Path!=SessionManager::instance().CurrentFilesDataBase.Path) {
             FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(DTXDB.Path,DTXDB.BaseName));
         }
     }
@@ -518,7 +519,7 @@ void AddFileToEditor::SelectedFilesInDocument()
     ui->filesSelected->show();
     connect(ui->filesSelected->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &AddFileToEditor::filesSelected_SelectionChanged);
-    DataTex::StretchColumns(ui->filesSelected,1.5);
+    SessionManager::instance().StretchColumns(ui->filesSelected,1.5);
 }
 
 void AddFileToEditor::on_RandomSelectionList_itemSelectionChanged()

--- a/datatex/addline.cpp
+++ b/datatex/addline.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "preamblesettings.h"
 #include "ui_preamblesettings.h"
 #include <QtCore>
@@ -19,8 +20,8 @@ PreambleSettings::PreambleSettings(QWidget *parent) :
     ui(new Ui::PreambleSettings)
 {
     ui->setupUi(this);
-    Packages = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Texlive_Packages",DataTex::DataTeX_Settings);
-    Descriptions = SqlFunctions::Get_StringList_From_Query("SELECT Description FROM Texlive_Packages",DataTex::DataTeX_Settings);
+    Packages = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Texlive_Packages",SessionManager::instance().DataTeX_Settings);
+    Descriptions = SqlFunctions::Get_StringList_From_Query("SELECT Description FROM Texlive_Packages",SessionManager::instance().DataTeX_Settings);
     filter = new QSortFilterProxyModel(this);
     model = new QStringListModel(Packages,this);
     filter->setSourceModel(model);
@@ -142,7 +143,7 @@ PreambleSettings::PreambleSettings(QWidget *parent) :
     });
 
     ui->TamplateTree->setColumnHidden(1,true);
-    QSqlQuery getTemplates(DataTex::DataTeX_Settings);
+    QSqlQuery getTemplates(SessionManager::instance().DataTeX_Settings);
     getTemplates.exec("SELECT Name,Preamble_Content,BuiltIn FROM Preambles");
     while(getTemplates.next()){
         QTreeWidgetItem * item = new QTreeWidgetItem();

--- a/datatex/backup.cpp
+++ b/datatex/backup.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "backup.h"
 #include "ui_backup.h"
 #include <QDirIterator>
@@ -63,13 +64,13 @@ BackUp::BackUp(QWidget *parent) :
         });
     }
     int i=0;
-    for (DTXDatabase DTXDB : DataTex::GlobalDatabaseList) {
+    for (DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList) {
         i++;
         QTreeWidgetItem * item = new QTreeWidgetItem();
         item->setText(3,DTXDB.BaseName);
         item->setText(2,DTXDB.Path);
         ui->OpenDatabasesTreeWidget->topLevelItem(DTXDB.Type)->addChild(item);
-//        QString DatabaseName = QFileInfo(DataTex::GlobalDatabaseList.values().at(i).databaseName()).baseName();
+//        QString DatabaseName = QFileInfo(SessionManager::instance().GlobalDatabaseList.values().at(i).databaseName()).baseName();
         QString fileCount = SqlFunctions::Get_String_From_Query("SELECT COUNT(Id) FROM Database_Files",DTXDB.Database);
 //        if(fileCount.count()){
             ui->OpenDatabasesTreeWidget->topLevelItem(DTXDB.Type)->child(i)->setText(1,fileCount+" files");
@@ -78,17 +79,17 @@ BackUp::BackUp(QWidget *parent) :
     }
 
     //Load all document databases
-//    for (int i=0;i<DataTex::GlobalDatabaseList.count();i++ ) {
+//    for (int i=0;i<SessionManager::instance().GlobalDatabaseList.count();i++ ) {
 //        QTreeWidgetItem * item = new QTreeWidgetItem();
-//        item->setText(3,QFileInfo(DataTex::GlobalDatabaseList.values().at(i).databaseName()).baseName());
-//        item->setText(2,DataTex::GlobalDatabaseList.values().at(i).databaseName());
+//        item->setText(3,QFileInfo(SessionManager::instance().GlobalDatabaseList.values().at(i).databaseName()).baseName());
+//        item->setText(2,SessionManager::instance().GlobalDatabaseList.values().at(i).databaseName());
 //        ui->OpenDatabasesTreeWidget->topLevelItem(1)->addChild(item);
-//        QString DatabaseName = QFileInfo(DataTex::GlobalDatabaseList.values().at(i).databaseName()).baseName();
-//        QStringList fileCount = SqlFunctions::Get_StringList_From_Query("SELECT COUNT(Id) FROM Documents",DataTex::GlobalDatabaseList[DatabaseName]);
+//        QString DatabaseName = QFileInfo(SessionManager::instance().GlobalDatabaseList.values().at(i).databaseName()).baseName();
+//        QStringList fileCount = SqlFunctions::Get_StringList_From_Query("SELECT COUNT(Id) FROM Documents",SessionManager::instance().GlobalDatabaseList[DatabaseName]);
 //        if(fileCount.count()){
 //            ui->OpenDatabasesTreeWidget->topLevelItem(1)->child(i)->setText(1,fileCount.at(0)+" documents");
 //        }
-//        ui->OpenDatabasesTreeWidget->topLevelItem(1)->child(i)->setText(0,DataTex::GlobalDocsDatabaseListNames.values().at(i));
+//        ui->OpenDatabasesTreeWidget->topLevelItem(1)->child(i)->setText(0,SessionManager::instance().GlobalDocsDatabaseListNames.values().at(i));
 //    }
     ui->OpenDatabasesTreeWidget->expandAll();
     ui->OpenDatabasesTreeWidget->header()->setSectionResizeMode(0,QHeaderView::ResizeToContents);
@@ -224,9 +225,9 @@ void BackUp::on_BackUpFilesButton_clicked()
                 QString CurrentBuildCommand = BuildComPreamble[QFileInfo(file).baseName()][0];
                 QString Preamble = BuildComPreamble[QFileInfo(file).baseName()][1];
                 DTXSettings dtxSettings;
-                DataTex::CurrentPreamble_Content = dtxSettings.getCurrentPreambleContent(Preamble);
+                SessionManager::instance().CurrentPreamble_Content = dtxSettings.getCurrentPreambleContent(Preamble);
                 FileCommands::CreateTexFile(file,0,"");
-                FileCommands::BuildDocument(DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX],file);//CurrentBuildCommand
+                FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX],file);//CurrentBuildCommand
                 FileCommands::ClearOldFiles(file);
             }
         }
@@ -295,14 +296,14 @@ void BackUp::on_OpenDatabasesTreeWidget_itemSelectionChanged()
             rem = " files";
             ContentType = "FileContent";
             DataTable = "Database_Files";
-            currentBase = DataTex::GlobalDatabaseList.value(item->text(3)).Database;
+            currentBase = SessionManager::instance().GlobalDatabaseList.value(item->text(3)).Database;
         }
         else if(ui->OpenDatabasesTreeWidget->currentIndex().parent().row()==1){
             Table = "DocMetadata";
             rem = " documents";
             ContentType = "Content";
             DataTable = "Documents";
-            currentBase = DataTex::GlobalDatabaseList.value(item->text(3)).Database;
+            currentBase = SessionManager::instance().GlobalDatabaseList.value(item->text(3)).Database;
         }
 
         Database_FileTableFields = SqlFunctions::Get_StringList_From_Query(QString("SELECT Id FROM BackUp WHERE Table_Id = '%1'").arg(Table),currentBase);

--- a/datatex/basefolder.cpp
+++ b/datatex/basefolder.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "basefolder.h"
 #include <QFileDialog>
 #include <QDir>
@@ -77,7 +78,7 @@ void BaseFolder::back() const
 InfoPage::InfoPage(QWidget *parent)
     : QWizardPage(parent)
 {
-    QSqlQuery DatabaseListQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery DatabaseListQuery;//(SessionManager::instance().DataTeX_Settings);
     DatabaseListQuery.exec("SELECT FileName FROM Databases");
     while (DatabaseListQuery.next()) {
         DatabaseList.append(DatabaseListQuery.value(0).toString());
@@ -332,7 +333,7 @@ void DataPage::initializePage()
         Table = "DocMetadata";
     }
 
-    QSqlQuery Select_DataBase_Metadata;//(DataTex::DataTeX_Settings);
+    QSqlQuery Select_DataBase_Metadata;//(SessionManager::instance().DataTeX_Settings);
     Select_DataBase_Metadata.exec(QString("SELECT Id,Name,DataType FROM "+Table+" WHERE Basic=1;"));
     while(Select_DataBase_Metadata.next()){
         BasicDataBaseFields.append(Select_DataBase_Metadata.value(0).toString());
@@ -490,7 +491,7 @@ void DataPage::RemoveField()
 //        scrollArea->setWidget(client);
 //        client->setLayout(BibliographyLayout);
 //        FieldTypes <<"TEXT"<<"INTEGER"<<"BLOB"<<"REAL"<<"NUMERIC";
-//        QSqlQuery Select_DataBase_Metadata(DataTex::DataTeX_Settings);
+//        QSqlQuery Select_DataBase_Metadata(SessionManager::instance().DataTeX_Settings);
 //        Select_DataBase_Metadata.exec(QString("SELECT Id,Name FROM Bibliography WHERE Basic=1"));
 //        while(Select_DataBase_Metadata.next()){
 //            BasicBibliographyFields.append(Select_DataBase_Metadata.value(0).toString());
@@ -718,7 +719,7 @@ void FinalPage::initializePage()
         table->setItem(BaseFolder::fields.count()+i,2 , new QTableWidgetItem(field("optCombo_"+QString::number(list.at(i))).toString()));
     }
 
-    DataTex::StretchColumnsToWidth(table);
+    SessionManager::instance().StretchColumnsToWidth(table);
 
     for (int i=0;i<table->rowCount() ;i++ ) {
         BaseFolder::Metadata.append(table->item(i,0)->text());
@@ -880,7 +881,7 @@ void BaseFolder::accept()
 //        BackUp1.exec(BackUpBib);
 //    }
     newdatabaseFile.close();
-        QSqlQuery AddNewDatabase;//(DataTex::DataTeX_Settings);
+        QSqlQuery AddNewDatabase;//(SessionManager::instance().DataTeX_Settings);
     QString Table;
     QString SettingsTable;
     QString MetaTable;
@@ -910,7 +911,7 @@ void BaseFolder::accept()
         }
     }
     MetadataQuery_1 +=MetadataEntries_1.join(",");
-    QSqlQuery Metadata_1;//(DataTex::DataTeX_Settings);
+    QSqlQuery Metadata_1;//(SessionManager::instance().DataTeX_Settings);
     Metadata_1.exec(MetadataQuery_1);
 
 //    if(BaseFolder::DatabaseType == "Files"){
@@ -924,7 +925,7 @@ void BaseFolder::accept()
 //            }
 //        }
 //        BibQuery_1 +=BibEntries_1.join(",");
-//        QSqlQuery Bibliography_1(DataTex::DataTeX_Settings);
+//        QSqlQuery Bibliography_1(SessionManager::instance().DataTeX_Settings);
 //        Bibliography_1.exec(BibQuery_1);
 
 //        QString BibQuery_2 = "INSERT INTO Bibliographic_Fields_per_Database (Database,Bibliographic_Field) VALUES ";
@@ -936,7 +937,7 @@ void BaseFolder::accept()
 //            BibEntries_2.append("(\""+baseFileName+"\",\""+BibliographyPage::newBiblabelList.at(i)->text()+"\")");
 //        }
 //        BibQuery_2 +=BibEntries_2.join(",");
-//        QSqlQuery Bibliography_2(DataTex::DataTeX_Settings);
+//        QSqlQuery Bibliography_2(SessionManager::instance().DataTeX_Settings);
 //        Bibliography_2.exec(BibQuery_2);
 //    }
 
@@ -950,7 +951,7 @@ void BaseFolder::accept()
         MetadataEntries_2.append("(\""+baseFileName+"\",\""+DataPage::newlabelList.at(i)->text()+"\")");
     }
     MetadataQuery_2 +=MetadataEntries_2.join(",");
-    QSqlQuery Metadata_2;//(DataTex::DataTeX_Settings);
+    QSqlQuery Metadata_2;//(SessionManager::instance().DataTeX_Settings);
     Metadata_2.exec(MetadataQuery_2);
     emit newbase(path,folderName,baseFileName,BaseFolder::DatabaseType);
     QDialog::accept();

--- a/datatex/bibauthorseditors.cpp
+++ b/datatex/bibauthorseditors.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "bibauthorseditors.h"
 #include "ui_bibauthorseditors.h"
 #include "qsqlquery.h"
@@ -10,9 +11,9 @@ BibAuthorsEditors::BibAuthorsEditors(QWidget *parent) :
     ui(new Ui::BibAuthorsEditors)
 {
     ui->setupUi(this);
-    QStringList authors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Authors",DataTex::Bibliography_Settings);
-    QStringList editors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Editors",DataTex::Bibliography_Settings);
-    QStringList translators;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Translators",DataTex::Bibliography_Settings);
+    QStringList authors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Authors",SessionManager::instance().Bibliography_Settings);
+    QStringList editors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Editors",SessionManager::instance().Bibliography_Settings);
+    QStringList translators;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Translators",SessionManager::instance().Bibliography_Settings);
     ui->AuthorsList->addItems(authors);
     ui->EditorsList->addItems(editors);
     ui->TranslatorList->addItems(translators);
@@ -54,7 +55,7 @@ BibAuthorsEditors::BibAuthorsEditors(QWidget *parent) :
     });
     connect(ui->NewAuthorButton,&QPushButton::clicked,this,[=](){
         QString text = ui->NewAuthorLine->text();
-        // QSqlQuery addAuthor(DataTex::Bibliography_Settings);
+        // QSqlQuery addAuthor(SessionManager::instance().Bibliography_Settings);
         // addAuthor.exec(QString("INSERT OR IGNORE INTO Authors (FullName) VALUES ('%1')").arg(text));
         // if(!authors.contains(text)){
         //     ui->AuthorsList->addItem(text);
@@ -62,7 +63,7 @@ BibAuthorsEditors::BibAuthorsEditors(QWidget *parent) :
         // }
     });
     connect(ui->NewEditorButton,&QPushButton::clicked,this,[=](){
-        // QSqlQuery addEditor(DataTex::Bibliography_Settings);
+        // QSqlQuery addEditor(SessionManager::instance().Bibliography_Settings);
         // QString text = ui->NewEditorLine->text();
         // addEditor.exec(QString("INSERT OR IGNORE INTO Editors (FullName) VALUES ('%1')").arg(text));
         // if(!editors.contains(text)){
@@ -72,7 +73,7 @@ BibAuthorsEditors::BibAuthorsEditors(QWidget *parent) :
     });
     connect(ui->NewTranslatorButton,&QPushButton::clicked,this,[=](){
         QString text = ui->NewTranslatorLine->text();
-        // QSqlQuery addTranslator(DataTex::Bibliography_Settings);
+        // QSqlQuery addTranslator(SessionManager::instance().Bibliography_Settings);
         // addTranslator.exec(QString("INSERT OR IGNORE INTO Translators (FullName) VALUES ('%1')").arg(text));
         // if(!translators.contains(text)){
         //     ui->TranslatorList->addItem(text);
@@ -90,19 +91,19 @@ BibAuthorsEditors::BibAuthorsEditors(QWidget *parent) :
         ui->DeleteTranslatorButton->setEnabled(ui->TranslatorList->selectionModel()->hasSelection());
     });
     connect(ui->DeleteAuthorButton,&QPushButton::clicked,this,[&](){
-        // QSqlQuery deleteQuery(DataTex::Bibliography_Settings);
+        // QSqlQuery deleteQuery(SessionManager::instance().Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Authors WHERE FullName = \"%1\"").arg(ui->AuthorsList->currentItem()->text()));
         // ui->AuthorsList->takeItem(ui->AuthorsList->currentRow());
     });
     connect(ui->DeleteEditorButton,&QPushButton::clicked,this,[&](){
-        // QSqlQuery deleteQuery(DataTex::Bibliography_Settings);
+        // QSqlQuery deleteQuery(SessionManager::instance().Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Editors WHERE FullName = \"%1\"").arg(ui->EditorsList->currentItem()->text()));
         // ui->EditorsList->takeItem(ui->EditorsList->currentRow());
     });
     connect(ui->DeleteTranslatorButton,&QPushButton::clicked,this,[&](){
-        // QSqlQuery deleteQuery(DataTex::Bibliography_Settings);
+        // QSqlQuery deleteQuery(SessionManager::instance().Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Translators WHERE FullName = \"%1\"").arg(ui->TranslatorList->currentItem()->text()));
         // ui->TranslatorList->takeItem(ui->TranslatorList->currentRow());

--- a/datatex/bibentry.cpp
+++ b/datatex/bibentry.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "bibentry.h"
 #include "ui_bibentry.h"
 #include <QDebug>
@@ -19,15 +20,15 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
     isEditMode = EditMode;
     isImportMode = ImportMode;
     editValues = values;
-    for (int i=0;i<DataTex::DocTypesIds.count();i++) {
-        ui->DocumentTypeCombo->addItem(DataTex::DocTypesNames[i],QVariant(DataTex::DocTypesIds[i]));
+    for (int i=0;i<SessionManager::instance().DocTypesIds.count();i++) {
+        ui->DocumentTypeCombo->addItem(SessionManager::instance().DocTypesNames[i],QVariant(SessionManager::instance().DocTypesIds[i]));
     }
-    OptBibFields;// = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Bibliography_Fields WHERE Basic = '0'",DataTex::Bibliography_Settings);
-    citationkeys;// = SqlFunctions::Get_StringList_From_Query("SELECT Citation_Key FROM Bibliography",DataTex::Bibliography_Settings);
+    OptBibFields;// = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Bibliography_Fields WHERE Basic = '0'",SessionManager::instance().Bibliography_Settings);
+    citationkeys;// = SqlFunctions::Get_StringList_From_Query("SELECT Citation_Key FROM Bibliography",SessionManager::instance().Bibliography_Settings);
     connect(ui->AddBibDocTypeButton,&QPushButton::clicked,this,[&](){
         AddDatabaseField * newData = new AddDatabaseField(this);
         connect(newData,&AddDatabaseField::newline,this,[=](QStringList Line){
-            // QSqlQuery AddField(DataTex::Bibliography_Settings);
+            // QSqlQuery AddField(SessionManager::instance().Bibliography_Settings);
             // AddField.exec(QString("INSERT OR IGNORE INTO DocumentTypes (Id,Name,Basic) "
             //                       "VALUES (\"%1\",\"%2\",\"%3\")").arg(Line[1],Line[0],"'0'"));
             // ui->DocumentTypeCombo->addItem(Line[1],QVariant("@"+Line[0]));
@@ -48,9 +49,9 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
     ui->EditorCombo->addItem(tr("Select an editor"));
     ui->TranslatorCombo->addItem(tr("Select a translator"));
 
-    authors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Authors",DataTex::Bibliography_Settings);
-    editors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Editors",DataTex::Bibliography_Settings);
-    translators;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Translators",DataTex::Bibliography_Settings);
+    authors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Authors",SessionManager::instance().Bibliography_Settings);
+    editors;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Editors",SessionManager::instance().Bibliography_Settings);
+    translators;// = SqlFunctions::Get_StringList_From_Query("SELECT * FROM Translators",SessionManager::instance().Bibliography_Settings);
     ui->AuthorsCombo->addItems(authors);
     ui->EditorCombo->addItems(editors);
     ui->TranslatorCombo->addItems(translators);
@@ -81,21 +82,21 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
         ui->AddAuthorButton->setEnabled(!ui->AuthorsCombo->currentText().isEmpty()
                                         && !ui->AuthorsCombo->currentText().isNull()
                                         && (ui->AuthorsCombo->currentIndex())>0
-                                        && !DataTex::GetListWidgetItems(ui->AuthorsList).contains(text));
+                                        && !SessionManager::instance().GetListWidgetItems(ui->AuthorsList).contains(text));
         ui->DeleteAuthorButton->setEnabled(ui->AuthorsCombo->currentIndex()>0);
     });
     connect(ui->EditorCombo,&QComboBox::currentTextChanged,this,[=](QString text){
         ui->AddEditorButton->setEnabled(!ui->EditorCombo->currentText().isEmpty()
                                         && !ui->EditorCombo->currentText().isNull()
                                         && (ui->EditorCombo->currentIndex())>0
-                                        && !DataTex::GetListWidgetItems(ui->EditorsList).contains(text));
+                                        && !SessionManager::instance().GetListWidgetItems(ui->EditorsList).contains(text));
         ui->DeleteEditorButton->setEnabled(ui->EditorCombo->currentIndex()>0);
     });
     connect(ui->TranslatorCombo,&QComboBox::currentTextChanged,this,[=](QString text){
         ui->AddTranslatorButton->setEnabled(!ui->TranslatorCombo->currentText().isEmpty()
                                             && !ui->TranslatorCombo->currentText().isNull()
                                             && (ui->TranslatorCombo->currentIndex())>0
-                                            && !DataTex::GetListWidgetItems(ui->TranslatorList).contains(text));
+                                            && !SessionManager::instance().GetListWidgetItems(ui->TranslatorList).contains(text));
         ui->DeleteTranslatorButton->setEnabled(ui->TranslatorCombo->currentIndex()>0);
     });
 
@@ -151,7 +152,7 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
 
     connect(ui->NewAuthorButton,&QPushButton::clicked,this,[=](){
         QString text = ui->NewAuthorLine->text();
-        // QSqlQuery addAuthor(DataTex::Bibliography_Settings);
+        // QSqlQuery addAuthor(SessionManager::instance().Bibliography_Settings);
         // addAuthor.exec(QString("INSERT OR IGNORE INTO Authors (FullName) VALUES ('%1')").arg(text));
         // ui->AuthorsCombo->addItem(text);
         // ui->AuthorsCombo->setCurrentIndex(ui->AuthorsCombo->count()-1);
@@ -160,7 +161,7 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
     });
     connect(ui->NewEditorButton,&QPushButton::clicked,this,[=](){
         QString text = ui->NewEditorButton->text();
-        // QSqlQuery addEditor(DataTex::Bibliography_Settings);
+        // QSqlQuery addEditor(SessionManager::instance().Bibliography_Settings);
         // addEditor.exec(QString("INSERT OR IGNORE INTO Editors (FullName) VALUES ('%1')").arg(text));
         // ui->EditorCombo->addItem(text);
         // ui->EditorCombo->setCurrentIndex(ui->EditorCombo->count()-1);
@@ -169,7 +170,7 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
     });
     connect(ui->NewTranslatorButton,&QPushButton::clicked,this,[=](){
         QString text = ui->NewTranslatorLine->text();
-        // QSqlQuery addTranslator(DataTex::Bibliography_Settings);
+        // QSqlQuery addTranslator(SessionManager::instance().Bibliography_Settings);
         // addTranslator.exec(QString("INSERT OR IGNORE INTO Translators (FullName) VALUES ('%1')").arg(text));
         // ui->TranslatorCombo->addItem(text);
         // ui->TranslatorCombo->setCurrentIndex(ui->TranslatorCombo->count()-1);
@@ -178,21 +179,21 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
     });
 
     connect(ui->DeleteAuthorButton,&QPushButton::clicked,this,[=](){
-        // QSqlQuery deleteQuery(DataTex::Bibliography_Settings);
+        // QSqlQuery deleteQuery(SessionManager::instance().Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Authors WHERE FullName = \"%1\"").arg(ui->AuthorsCombo->currentText()));
         // authors.removeAll(ui->AuthorsCombo->currentText());
         // ui->AuthorsCombo->removeItem(ui->AuthorsCombo->currentIndex());
     });
     connect(ui->DeleteEditorButton,&QPushButton::clicked,this,[&](){
-        // QSqlQuery deleteQuery(DataTex::Bibliography_Settings);
+        // QSqlQuery deleteQuery(SessionManager::instance().Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Editors WHERE FullName = \"%1\"").arg(ui->EditorCombo->currentText()));
         // editors.removeAll(ui->EditorCombo->currentText());
         // ui->EditorCombo->removeItem(ui->EditorCombo->currentIndex());
     });
     connect(ui->DeleteTranslatorButton,&QPushButton::clicked,this,[&](){
-        // QSqlQuery deleteQuery(DataTex::Bibliography_Settings);
+        // QSqlQuery deleteQuery(SessionManager::instance().Bibliography_Settings);
         // deleteQuery.exec("PRAGMA foreign_keys = ON");
         // deleteQuery.exec(QString("DELETE FROM Translators WHERE FullName = \"%1\"").arg(ui->TranslatorCombo->currentText()));
         // translators.removeAll(ui->TranslatorCombo->currentText());
@@ -200,7 +201,7 @@ BibEntry::BibEntry(QWidget *parent, bool EditMode, bool ImportMode, QHash<QStrin
     });
     ui->CustomFieldsTable->setColumnCount(2);
     ui->CustomFieldsTable->setHorizontalHeaderLabels({tr("Id"),tr("Value")});
-    DataTex::StretchColumnsToWidth(ui->CustomFieldsTable);
+    SessionManager::instance().StretchColumnsToWidth(ui->CustomFieldsTable);
     if(isEditMode){BibEditMode();}
     if(isImportMode){BibEditMode();}
     ui->buttonBox->setHidden(isImportMode);
@@ -274,7 +275,7 @@ void BibEntry::on_buttonBox_accepted()
     }
 
     else{
-        // QSqlQuery editBibEntry(DataTex::Bibliography_Settings);
+        // QSqlQuery editBibEntry(SessionManager::instance().Bibliography_Settings);
         // QStringList list;
         // for(QString text:bibValues.keys()){
         //     list.append(text+"='"+bibValues[text]+"'");
@@ -293,11 +294,11 @@ QString BibEntry::BibSourceCode()
     if(!ui->TitleLine->text().isEmpty() && !ui->TitleLine->text().isNull()){
             sourceCode += "\t title = {"+ui->TitleLine->text()+"}"+",\n";}
     if((!ui->AuthorsList->count())==0){
-        sourceCode += "\t author = {"+DataTex::GetListWidgetItems(ui->AuthorsList).join(" and ")+"}"+",\n";}
+        sourceCode += "\t author = {"+SessionManager::instance().GetListWidgetItems(ui->AuthorsList).join(" and ")+"}"+",\n";}
     if((!ui->EditorsList->count())==0){
-        sourceCode += "\t editor = {"+DataTex::GetListWidgetItems(ui->EditorsList).join(" and ")+"}"+",\n";}
+        sourceCode += "\t editor = {"+SessionManager::instance().GetListWidgetItems(ui->EditorsList).join(" and ")+"}"+",\n";}
     if((!ui->TranslatorList->count())==0){
-        sourceCode += "\t translator = {"+DataTex::GetListWidgetItems(ui->TranslatorList).join(" and ")+"}"+",\n";}
+        sourceCode += "\t translator = {"+SessionManager::instance().GetListWidgetItems(ui->TranslatorList).join(" and ")+"}"+",\n";}
 
     if(!ui->PublisherLine->text().isEmpty() && !ui->PublisherLine->text().isNull()){
             sourceCode += "\t publisher = {"+ui->PublisherLine->text()+"}"+",\n";}
@@ -397,11 +398,11 @@ QHash<QString, QString> BibEntry::getBibValues()
 
 void BibEntry::InsertValues(QHash<QString,QString> values)
 {
-    // QSqlQuery writeBibEntry(DataTex::Bibliography_Settings);
+    // QSqlQuery writeBibEntry(SessionManager::instance().Bibliography_Settings);
     // writeBibEntry.exec(QString("INSERT INTO Bibliography ("+values.keys().join(",")+") VALUES (\""+
     //                            values.values().join("\",\"")+"\")"));
     // if(ui->AuthorsList->count()>0){
-    //     for(QString author:DataTex::GetListWidgetItems(ui->AuthorsList)){
+    //     for(QString author:SessionManager::instance().GetListWidgetItems(ui->AuthorsList)){
     //         writeBibEntry.exec(QString("INSERT OR IGNORE INTO Authors (FullName) "
     //                                    "VALUES (\""+author+"\")"));
     //         writeBibEntry.exec(QString("INSERT OR IGNORE INTO Authors_per_BibEntry (FullName,BibEntry_Id) "
@@ -409,7 +410,7 @@ void BibEntry::InsertValues(QHash<QString,QString> values)
     //     }
     // }
     // if(ui->EditorsList->count()>0){
-    //     for(QString editor:DataTex::GetListWidgetItems(ui->EditorsList)){
+    //     for(QString editor:SessionManager::instance().GetListWidgetItems(ui->EditorsList)){
     //         writeBibEntry.exec(QString("INSERT OR IGNORE INTO Editors (FullName) "
     //                                    "VALUES (\""+editor+"\")"));
     //         writeBibEntry.exec(QString("INSERT OR IGNORE INTO Editors_per_BibEntry (FullName,BibEntry_Id) "
@@ -417,14 +418,14 @@ void BibEntry::InsertValues(QHash<QString,QString> values)
     //     }
     // }
     // if(ui->TranslatorList->count()>0){
-    //     for(QString translator:DataTex::GetListWidgetItems(ui->TranslatorList)){
+    //     for(QString translator:SessionManager::instance().GetListWidgetItems(ui->TranslatorList)){
     //         writeBibEntry.exec(QString("INSERT OR IGNORE INTO Translators (FullName) "
     //                                    "VALUES (\""+translator+"\")"));
     //         writeBibEntry.exec(QString("INSERT OR IGNORE INTO Translators_per_BibEntry (FullName,BibEntry_Id) "
     //                                    "VALUES (\""+translator+"\",\""+ui->CitationKeyLine->text()+"\")"));
     //     }
     // }
-    // QSqlQuery writeSourceCode(DataTex::Bibliography_Settings);
+    // QSqlQuery writeSourceCode(SessionManager::instance().Bibliography_Settings);
     // writeSourceCode.exec("INSERT INTO EntrySourceCode (BibId,SourceCode) VALUES "
     //                      "(\""+ui->CitationKeyLine->text()+"\",\""+BibSourceCode()+"\")");
 }

--- a/datatex/clonedatabasefile.cpp
+++ b/datatex/clonedatabasefile.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "clonedatabasefile.h"
 #include "ui_clonedatabasefile.h"
 
@@ -6,12 +7,12 @@ CloneDatabaseFile::CloneDatabaseFile(QWidget *parent) :
     ui(new Ui::CloneDatabaseFile)
 {
     ui->setupUi(this);
-    for (DTXDatabase DTXDB:DataTex::GlobalDatabaseList) {
-        if(DTXDB.Path != DataTex::CurrentFilesDataBase.Path){
+    for (DTXDatabase DTXDB:SessionManager::instance().GlobalDatabaseList) {
+        if(DTXDB.Path != SessionManager::instance().CurrentFilesDataBase.Path){
             ui->FilesDatabasesCombo->addItem(DTXDB.Description,QVariant::fromValue(DTXDB));
         }
     }
-    SourceDatabase = ui->FilesDatabasesCombo->currentData().value<DTXDatabase>();//DataTex::GlobalDatabaseList[QFileInfo(ui->FilesDatabasesCombo->currentData().toString()).baseName()];
+    SourceDatabase = ui->FilesDatabasesCombo->currentData().value<DTXDatabase>();//SessionManager::instance().GlobalDatabaseList[QFileInfo(ui->FilesDatabasesCombo->currentData().toString()).baseName()];
     SourceDatabaseName = SourceDatabase.Description;
     ui->FilesDatabasesCombo->setCurrentText(SourceDatabaseName);
     ui->removeButton->setEnabled(false);
@@ -31,10 +32,10 @@ CloneDatabaseFile::CloneDatabaseFile(QWidget *parent) :
     FilesTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     FilesTable->horizontalHeader()->setSectionsClickable(true);
     FilesTable->setAlternatingRowColors(true);
-    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp",DataTex::CurrentFilesDataBase.Database);
-    Database_FileTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",DataTex::CurrentFilesDataBase.Database);
+    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp",SessionManager::instance().CurrentFilesDataBase.Database);
+    Database_FileTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp",SessionManager::instance().CurrentFilesDataBase.Database);
     LoadDatabaseFiles(SourceDatabase.Database);
-    DataTex::StretchColumns(FilesTable,1.5);
+    SessionManager::instance().StretchColumns(FilesTable,1.5);
 //    ui->FilesDatabasesCombo->setEnabled(false);
 
     connect(FilesTable,&QTableView::doubleClicked,this,[=](){
@@ -73,7 +74,7 @@ CloneDatabaseFile::CloneDatabaseFile(QWidget *parent) :
         int row = FilesTable->currentIndex().row();
         AddFiles(row);
     });
-    DestinationDatabase = DataTex::CurrentFilesDataBase;
+    DestinationDatabase = SessionManager::instance().CurrentFilesDataBase;
     ui->ImportButton->setChecked(true);
     connect(ui->ImportButton,&QPushButton::toggled,this,[&](bool checked){
         int filesSelected = ui->SelectedFiles->model()->rowCount();
@@ -107,11 +108,11 @@ CloneDatabaseFile::CloneDatabaseFile(QWidget *parent) :
         }
         if(checked){
             SourceDatabase = ui->FilesDatabasesCombo->currentData().value<DTXDatabase>();
-            DestinationDatabase = DataTex::CurrentFilesDataBase;
+            DestinationDatabase = SessionManager::instance().CurrentFilesDataBase;
         }
         else
         {
-            SourceDatabase = DataTex::CurrentFilesDataBase;
+            SourceDatabase = SessionManager::instance().CurrentFilesDataBase;
         }
         LoadDatabaseFiles(SourceDatabase.Database);
     });
@@ -157,7 +158,7 @@ void CloneDatabaseFile::LoadDatabaseFiles(QSqlDatabase database)
     FilesTable->generateFilters(columns,false);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this, &CloneDatabaseFile::FilesTable_selectionchanged);
     connect(FilesTable->filterHeader(), &FilterTableHeader::filterValues, this, &CloneDatabaseFile::updateFilter);
-    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
     FilesTable->filterHeader()->adjustPositions();
 }
 
@@ -166,11 +167,11 @@ void CloneDatabaseFile::updateFilter(QStringList values)
     SqlFunctions::FilterTable(Database_FileTableFields,values);
     int columns = Database_FileTableFields.count();
     FilesTable->setColumnHidden(columns,true);
-    DataTex::updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,SourceDatabase.Database,this);
+    SessionManager::instance().updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,SourceDatabase.Database,this);
     FilesTable->filterTable(SqlFunctions::FilesTable_UpdateQuery,SourceDatabase.Database,filesSorting);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &CloneDatabaseFile::FilesTable_selectionchanged);
-    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
 }
 
 void CloneDatabaseFile::FilesTable_selectionchanged()
@@ -187,7 +188,7 @@ void CloneDatabaseFile::FilesTable_selectionchanged()
     QString pdffile = file.replace(".tex",".pdf");
     if(!QFileInfo::exists(pdffile)){
         //        FileCommands::CreateTexFile(PreviewFile,0,""/*preamble*/);
-        //        FileCommands::BuildDocument(DataTex::DTXBuildCommands[buildCommand],PreviewFile,DataTex::LatexCommandsArguments[buildCommand],".tex");
+        //        FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[buildCommand],PreviewFile,SessionManager::instance().LatexCommandsArguments[buildCommand],".tex");
         //        FileCommands::ClearOldFiles(PreviewFile);
         //Need to add a 'preamble' variable in CreateTexFile command
     }
@@ -273,8 +274,8 @@ void CloneDatabaseFile::AddFiles(int row)
 
                 if(!isImportMode){
                     QComboBox *comboBox = new QComboBox(this);
-                    for (DTXDatabase DTXDB:DataTex::GlobalDatabaseList) {
-                        if(DTXDB.Path != DataTex::CurrentFilesDataBase.Path){
+                    for (DTXDatabase DTXDB:SessionManager::instance().GlobalDatabaseList) {
+                        if(DTXDB.Path != SessionManager::instance().CurrentFilesDataBase.Path){
                             comboBox->addItem(DTXDB.Description,QVariant::fromValue(DTXDB));
                             subitem->setData(1,Qt::UserRole,QVariant::fromValue(comboBox->currentData().value<DTXDatabase>()));
                         }
@@ -403,7 +404,7 @@ void CloneDatabaseFile::on_Okbutton_accepted()
     for (DTXFile * info: FileList) {
         if(info->misc.value<int>()==NewFileMode::CloneModeContentAndMetadata){
             //Sql queries to clone metadata to destination database
-            QSqlQuery WriteData(DataTex::CurrentFilesDataBase.Database);
+            QSqlQuery WriteData(SessionManager::instance().CurrentFilesDataBase.Database);
             WriteData.exec(QString("INSERT OR IGNORE INTO Fields (Id,Name) VALUES(\"%1\",\"%2\")").arg(info->Field.Id,info->Field.Name));
             for (DTXChapter chapter:info->Chapters) {
                 WriteData.exec(QString("INSERT OR IGNORE INTO Chapters (Id,Name,Field) VALUES(\"%1\",\"%2\",\"%3\")")
@@ -455,19 +456,19 @@ void CloneDatabaseFile::on_Okbutton_accepted()
 
     connect(file,&NewDatabaseFile::acceptClone,this,[=](){
         for (DTXFile *fileinfo:FileList) {
-            //            fileinfo->Content = FileCommands::NewFileText(fileinfo->Id,fileinfo->Content,DataTex::CurrentFilesDataBase.Database);
-            FileCommands::AddNewFileToDatabase(fileinfo,DataTex::CurrentFilesDataBase.Database);
+            //            fileinfo->Content = FileCommands::NewFileText(fileinfo->Id,fileinfo->Content,SessionManager::instance().CurrentFilesDataBase.Database);
+            FileCommands::AddNewFileToDatabase(fileinfo,SessionManager::instance().CurrentFilesDataBase.Database);
             emit acceptSignal(fileinfo->Path);
             delete fileinfo;
         }
         for (DTXFile *solutioninfo:SolutionsList) {
             DTXFile *info = solutioninfo->misc.value<DTXFile*>();
             QString content = solutioninfo->Content;
-            solutioninfo = FileCommands::CreateSolutionData(info,DataTex::CurrentFilesDataBase.Database);
+            solutioninfo = FileCommands::CreateSolutionData(info,SessionManager::instance().CurrentFilesDataBase.Database);
             content = FileCommands::ClearMetadataFromContent(content);
-            solutioninfo->Content = FileCommands::NewFileText(solutioninfo->Id,content,DataTex::CurrentFilesDataBase.Database);
-            FileCommands::AddNewFileToDatabase(solutioninfo,DataTex::CurrentFilesDataBase.Database);
-            QSqlQuery solutions_per_file(DataTex::CurrentFilesDataBase.Database);
+            solutioninfo->Content = FileCommands::NewFileText(solutioninfo->Id,content,SessionManager::instance().CurrentFilesDataBase.Database);
+            FileCommands::AddNewFileToDatabase(solutioninfo,SessionManager::instance().CurrentFilesDataBase.Database);
+            QSqlQuery solutions_per_file(SessionManager::instance().CurrentFilesDataBase.Database);
             solutions_per_file.exec(QString("INSERT INTO Solutions_per_File (Solution_Id,Solution_Path,File_Id) VALUES ('%1', '%2','%3');").arg(solutioninfo->Id,solutioninfo->Path,info->Id));
             delete info;
             delete solutioninfo;
@@ -502,7 +503,7 @@ void CloneDatabaseFile::CreateCustomTagWidget(QSqlDatabase database)
 //    }
 //    else {
 //        ui->FilesDatabasesCombo->setEnabled(checked);
-//        LoadDatabaseFiles(DataTex::CurrentFilesDataBase.Database);
+//        LoadDatabaseFiles(SessionManager::instance().CurrentFilesDataBase.Database);
 //        FilesTable->filterHeader()->adjustPositions();
 //    }
 //}
@@ -510,12 +511,12 @@ void CloneDatabaseFile::CreateCustomTagWidget(QSqlDatabase database)
 void CloneDatabaseFile::on_FilesDatabasesCombo_activated(int index)
 {
     if(index>-1 /*&& ui->checkBox->isChecked()*/){
-//        for (int i=0;i<DataTex::GlobalDatabaseList.count();i++) {
-//            if(DataTex::GlobalDatabaseList.values()[i]==ui->FilesDatabasesCombo->currentData().value<QSqlDatabase>()){
+//        for (int i=0;i<SessionManager::instance().GlobalDatabaseList.count();i++) {
+//            if(SessionManager::instance().GlobalDatabaseList.values()[i]==ui->FilesDatabasesCombo->currentData().value<QSqlDatabase>()){
 //                index = i;
 //            }
 //        }
-        SourceDatabase = ui->FilesDatabasesCombo->currentData().value<DTXDatabase>();//DataTex::GlobalDatabaseList.values().at(index);
+        SourceDatabase = ui->FilesDatabasesCombo->currentData().value<DTXDatabase>();//SessionManager::instance().GlobalDatabaseList.values().at(index);
         LoadDatabaseFiles(SourceDatabase.Database);
     }
     ui->FilesTagFilter->setChecked(false);

--- a/datatex/csvfunctions.cpp
+++ b/datatex/csvfunctions.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "csvfunctions.h"
 #include <QSqlQueryModel>
 
@@ -118,8 +119,8 @@ QString CsvFunctions::getFile(QString file,QString databasepath)
     text = "SELECT df.Id ,ft.Name AS FileType,f.Name AS Field, replace(group_concat(DISTINCT c.Name),',','|') AS Chapter, "
                    "replace(group_concat(DISTINCT s.Name),',','|') AS Section,replace(group_concat(DISTINCT et.Name),',','|') AS ExerciseType,Difficulty,Path, "
                    "Date,Solved_Prooved,replace(group_concat(DISTINCT bpf.Bib_Id),',','|') AS Bibliography,FileContent,Preamble,BuildCommand,FileDescription ";
-            if(DataTex::CurrentDTXDataBase.customFieldIds().count()>0)
-            {text += ","+DataTex::CurrentDTXDataBase.customFieldIds().join(",");}
+            if(SessionManager::instance().CurrentDTXDataBase.customFieldIds().count()>0)
+            {text += ","+SessionManager::instance().CurrentDTXDataBase.customFieldIds().join(",");}
             text += ", replace(group_concat(DISTINCT t.Tag_Id),',','|') AS Custom_Tags";
             text +=" FROM Database_Files df JOIN FileTypes ft ON ft.Id = df.FileType JOIN Fields f ON f.Id = df.Field "
                    "JOIN Chapters_per_File cpf ON cpf.File_Id=df.Id "
@@ -142,8 +143,8 @@ QString CsvFunctions::getDocument(QString file,QString databasepath)
     QString text;
     text = "SELECT d.Id,d.Title,d.Document_Type,d.Basic_Folder,d.SubFolder,d.SubsubFolder,d.Path,d.Date,d.Content,d.Preamble, "
            "d.BuildCommand,d.NeedsUpdate,d.Bibliography,d.UseBibliography,d.Description ";
-    if(DataTex::Optional_DocMetadata_Ids[QFileInfo(databasepath).baseName()].count()>0)
-    {text += ","+DataTex::Optional_DocMetadata_Ids[QFileInfo(databasepath).baseName()].join(",");}
+    if(SessionManager::instance().Optional_DocMetadata_Ids[QFileInfo(databasepath).baseName()].count()>0)
+    {text += ","+SessionManager::instance().Optional_DocMetadata_Ids[QFileInfo(databasepath).baseName()].join(",");}
     text += ",replace(group_concat(DISTINCT fd.File_Id || '<<' || fd.Files_Database_Source || '>>'),',','|') AS Files_in_Document,"
             "replace(group_concat(DISTINCT bd.Bib_Id),',','|') AS Bib_Entries,"
             " replace(group_concat(DISTINCT t.Tag_Id),',','|') AS Custom_Tags ";

--- a/datatex/databasecreator.cpp
+++ b/datatex/databasecreator.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "databasecreator.h"
 #include "ui_databasecreator.h"
 #include <QObject>
@@ -364,7 +365,7 @@ bool DatabaseCreator::ItemHasTopic(QListWidgetItem * item)
 void DatabaseCreator::on_DatabaseCreator_accepted()
 {
     QString FullPath = NewDatabase.Path+QDir::separator()+NewDatabase.Description+QDir::separator()+NewDatabase.BaseName+".db";
-    QSqlQuery AddNewDatabase;//(DataTex::DataTeX_Settings);
+    QSqlQuery AddNewDatabase;//(SessionManager::instance().DataTeX_Settings);
 
     QJsonDocument newDatabaseInfo;
     QJsonObject basicObject;
@@ -405,7 +406,7 @@ void DatabaseCreator::on_DatabaseCreator_accepted()
     basicObject["Metadata"] = metaArray;
     newDatabaseInfo.setObject(basicObject);
 
-    QString path = DataTex::datatexpath+"Databases/";
+    QString path = SessionManager::instance().datatexpath+"Databases/";
     QDir dir(path);
     if (!dir.exists())dir.mkpath(path);
     QFile file(path+NewDatabase.BaseName+".json");
@@ -547,8 +548,8 @@ DTXFileType::DTXFileType(QStringList list)
 
 DTXDatabase DTXDatabaseInfo::getDTXDatabase()
 {
-    if(DataTex::GlobalDatabaseList.value(Id).Type == Type){
-        return DataTex::GlobalDatabaseList.value(Id);
+    if(SessionManager::instance().GlobalDatabaseList.value(Id).Type == Type){
+        return SessionManager::instance().GlobalDatabaseList.value(Id);
     }
 }
 

--- a/datatex/databasesync.cpp
+++ b/datatex/databasesync.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "databasesync.h"
 #include "ui_databasesync.h"
 #include "sqlfunctions.h"
@@ -16,7 +17,7 @@ DatabaseSync::DatabaseSync(QWidget *parent) :
 
     //Load all file databases
     int i=-1;
-    for (DTXDatabase DTXDB : DataTex::GlobalDatabaseList) {
+    for (DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList) {
         i++;
         QTreeWidgetItem * item = new QTreeWidgetItem();
         item->setText(3,DTXDB.BaseName);
@@ -37,7 +38,7 @@ DatabaseSync::DatabaseSync(QWidget *parent) :
         ui->buttonGroup->buttons().at(i)->setEnabled(false);
     }
     ui->MetadataDifferences->setHorizontalHeaderLabels({"Database field","Values in csv","Values in database"});
-    DataTex::StretchColumnsToWidth(ui->MetadataDifferences);
+    SessionManager::instance().StretchColumnsToWidth(ui->MetadataDifferences);
     ui->MetadataDifferences->setColumnHidden(3,true);
     FoundFont.setBold(true);
     redBrush=(QColor(200, 20, 20 ));
@@ -67,14 +68,14 @@ void DatabaseSync::on_OpenDatabasesTreeWidget_itemClicked(QTreeWidgetItem *item,
             rem = " files";
             ContentType = "FileContent";
             DataTable = "Database_Files";
-            currentBase = DataTex::GlobalDatabaseList.value(item->text(3)).Database;
+            currentBase = SessionManager::instance().GlobalDatabaseList.value(item->text(3)).Database;
         }
         else if(ui->OpenDatabasesTreeWidget->currentIndex().parent().row()==1){
             Table = "DocMetadata";
             rem = " documents";
             ContentType = "Content";
             DataTable = "Documents";
-            currentBase = DataTex::GlobalDatabaseList.value(item->text(3)).Database;
+            currentBase = SessionManager::instance().GlobalDatabaseList.value(item->text(3)).Database;
         }
         for (int i=0;i<ui->buttonGroup->buttons().count();i++) {
             ui->buttonGroup->buttons().at(i)->setEnabled(true);
@@ -131,7 +132,7 @@ void DatabaseSync::on_ResultsTreeWidget_itemSelectionChanged()
             ui->MetadataDifferences->setItem(i,1, new QTableWidgetItem(DifferencesInCSV[baseName][key]));
             ui->MetadataDifferences->setItem(i,2, new QTableWidgetItem(DifferencesInDatabase[baseName][key]));
         }
-        DataTex::StretchColumnsToWidth(ui->MetadataDifferences);
+        SessionManager::instance().StretchColumnsToWidth(ui->MetadataDifferences);
     }
 
     if(topLevel==2 && index.parent().isValid()){
@@ -484,12 +485,12 @@ void DatabaseSync::Sync(FileScanResults results)
         // qDebug()<<results.Id<<"  5. Mirror from csv";
     }
     if(results.CreateMissingFileFlag & CreatePdf){
-//        DataTex::CurrentPreamble_Content = SqlFunctions::Get_String_From_Query(QString(SqlFunctions::GetPreamble_Content)
+//        SessionManager::instance().CurrentPreamble_Content = SqlFunctions::Get_String_From_Query(QString(SqlFunctions::GetPreamble_Content)
 //                                                                       .arg(Preamble)
-//                                                                   ,DataTex::DataTeX_Settings);
+//                                                                   ,SessionManager::instance().DataTeX_Settings);
 //        FileCommands::CreateTexFile(results.Path,0,"");
-//        FileCommands::BuildDocument(DataTex::DTXBuildCommands[results.BuildCommand],results.Path
-//                                    ,DataTex::LatexCommandsArguments[results.BuildCommand],".tex");
+//        FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[results.BuildCommand],results.Path
+//                                    ,SessionManager::instance().LatexCommandsArguments[results.BuildCommand],".tex");
 //        FileCommands::ClearOldFiles(results.Path);
         // qDebug()<<results.Id<<"  6. Create pdf";
     }

--- a/datatex/datatables.cpp
+++ b/datatex/datatables.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "datatables.h"
 #include "ui_datatables.h"
 
@@ -8,8 +9,8 @@ DataTables::DataTables(QWidget *parent)
     , ui(new Ui::DataTables)
 {
     ui->setupUi(this);
-    currentbase = DataTex::CurrentFilesDataBase.Database;
-    currentbase_Notes = DataTex::CurrentDocumentsDataBase.Database;
+    currentbase = SessionManager::instance().CurrentFilesDataBase.Database;
+    currentbase_Notes = SessionManager::instance().CurrentDocumentsDataBase.Database;
     ui->FieldTable->setColumnCount(2);
     ui->FieldTable->setHorizontalHeaderLabels({tr("Field name"),tr("Primary key")});
     ui->FieldTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
@@ -48,14 +49,14 @@ DataTables::DataTables(QWidget *parent)
     ui->FileTypeTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     LoadFileTypes();
     LoadTags();
-    for(DTXDatabase DTXDB : DataTex::GlobalDatabaseList){
+    for(DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList){
         ui->FilesDBCombo->addItem(DTXDB.Description,QVariant::fromValue(DTXDB));
     }
-    ui->FilesDBCombo->setCurrentText(DataTex::CurrentFilesDataBase.Description);
-    for(DTXDatabase DTXDB : DataTex::GlobalDatabaseList){
+    ui->FilesDBCombo->setCurrentText(SessionManager::instance().CurrentFilesDataBase.Description);
+    for(DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList){
         ui->DocsDBCombo->addItem(DTXDB.Description,QVariant::fromValue(DTXDB));
     }
-    ui->DocsDBCombo->setCurrentText(DataTex::GlobalDatabaseList.value(QFileInfo(DataTex::CurrentDocumentsDataBase.Path).baseName()).Description);
+    ui->DocsDBCombo->setCurrentText(SessionManager::instance().GlobalDatabaseList.value(QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).baseName()).Description);
     connect(ui->FilesDBCombo,&QComboBox::textActivated,this,[=](){
         currentbase = ui->FilesDBCombo->currentData().value<DTXDatabase>().Database;
         LoadLists();
@@ -64,7 +65,7 @@ DataTables::DataTables(QWidget *parent)
         LoadTags();
     });
     connect(ui->DocsDBCombo,&QComboBox::textActivated,this,[=](){
-        currentbase_Notes = DataTex::GlobalDatabaseList.value(QFileInfo(ui->DocsDBCombo->currentData().toString()).baseName()).Database;
+        currentbase_Notes = SessionManager::instance().GlobalDatabaseList.value(QFileInfo(ui->DocsDBCombo->currentData().toString()).baseName()).Database;
         LoadDocumentTypes();
     });
 
@@ -244,17 +245,17 @@ void DataTables::LoadLists()
     FileTypeNames.clear();
     FileTypeFolders.clear();
     CustomTags.clear();
-    FieldIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Fields",DataTex::CurrentFilesDataBase.Database));
-    FieldNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Fields",DataTex::CurrentFilesDataBase.Database));
-    ChapterIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Chapters",DataTex::CurrentFilesDataBase.Database));
-    ChapterNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Chapters",DataTex::CurrentFilesDataBase.Database));
-    SectionIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Sections",DataTex::CurrentFilesDataBase.Database));
-    SectionNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Sections",DataTex::CurrentFilesDataBase.Database));
-    ExTypeIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Exercise_Types WHERE id <> '-'",DataTex::CurrentFilesDataBase.Database));
-    ExTypeNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Exercise_Types WHERE id <> '-'",DataTex::CurrentFilesDataBase.Database));
-    FileTypeIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM FileTypes",DataTex::CurrentFilesDataBase.Database));
-    FileTypeNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM FileTypes",DataTex::CurrentFilesDataBase.Database));
-    FileTypeFolders.append(SqlFunctions::Get_StringList_From_Query("SELECT FolderName FROM FileTypes",DataTex::CurrentFilesDataBase.Database));
+    FieldIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Fields",SessionManager::instance().CurrentFilesDataBase.Database));
+    FieldNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Fields",SessionManager::instance().CurrentFilesDataBase.Database));
+    ChapterIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Chapters",SessionManager::instance().CurrentFilesDataBase.Database));
+    ChapterNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Chapters",SessionManager::instance().CurrentFilesDataBase.Database));
+    SectionIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Sections",SessionManager::instance().CurrentFilesDataBase.Database));
+    SectionNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Sections",SessionManager::instance().CurrentFilesDataBase.Database));
+    ExTypeIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Exercise_Types WHERE id <> '-'",SessionManager::instance().CurrentFilesDataBase.Database));
+    ExTypeNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Exercise_Types WHERE id <> '-'",SessionManager::instance().CurrentFilesDataBase.Database));
+    FileTypeIds.append(SqlFunctions::Get_StringList_From_Query("SELECT Id FROM FileTypes",SessionManager::instance().CurrentFilesDataBase.Database));
+    FileTypeNames.append(SqlFunctions::Get_StringList_From_Query("SELECT Name FROM FileTypes",SessionManager::instance().CurrentFilesDataBase.Database));
+    FileTypeFolders.append(SqlFunctions::Get_StringList_From_Query("SELECT FolderName FROM FileTypes",SessionManager::instance().CurrentFilesDataBase.Database));
 }
 
 void DataTables::LoadFields()
@@ -541,7 +542,7 @@ void DataTables::on_buttonBox_rejected()
 
 void DataTables::on_EditFieldButton_clicked()
 {
-    DataTex::FunctionInProgress();
+    SessionManager::instance().FunctionInProgress();
 //    int row = ui->FieldTable->currentRow();
 //    QStringList line;
 //    line.append(ui->FieldTable->item(row, 0)->text());
@@ -630,7 +631,7 @@ void DataTables::UpdateDatabaseMetadata(QString Id, QString DBField, QString old
 
 void DataTables::on_EditChapterButton_clicked()
 {
-    DataTex::FunctionInProgress();
+    SessionManager::instance().FunctionInProgress();
 //    int row = ui->ChapterTable->currentRow();
 //    QStringList line;
 //    line.append(ui->ChapterTable->item(row, 0)->text());
@@ -678,7 +679,7 @@ void DataTables::EditChapter(QStringList Line)
 
 void DataTables::on_EditSectionButton_clicked()
 {
-    DataTex::FunctionInProgress();
+    SessionManager::instance().FunctionInProgress();
 //    int row = ui->SectionTable->currentRow();
 //    QStringList line;
 //    line.append(ui->SectionTable->item(row, 0)->text());
@@ -763,7 +764,7 @@ void DataTables::on_RemDocumentTypeButton_clicked()
 
 void DataTables::on_EditDocumentTypeButton_clicked()
 {
-    DataTex::FunctionInProgress();
+    SessionManager::instance().FunctionInProgress();
 //    QString eidos = ui->DocumentTypeTable->currentItem()->text();
 //    newFolder = new addfolder(this);
 //    newFolder->EditFolder(eidos);
@@ -954,7 +955,7 @@ void DataTables::on_RemoveExerciseTypeButton_clicked()
 
 void DataTables::on_EditExerciseTypeButton_clicked()
 {
-    DataTex::FunctionInProgress();
+    SessionManager::instance().FunctionInProgress();
 //    int row = ui->ExerciseTypeTable->currentRow();
 //    QStringList line;
 //    line.append(ui->ExerciseTypeTable->item(row, 0)->text());
@@ -1004,7 +1005,7 @@ void DataTables::on_AddFileTypeButton_clicked()
 
     NewFileType * newFile = new NewFileType(this,(DTXDatabaseType)DTXDatabaseType::FilesDB);
     connect(newFile,&NewFileType::filedata,this,[=](DTXFileType filetype){
-        NewFileType::CreateNewDatabaseFileType(DataTex::CurrentFilesDataBase.Database,DataTex::CurrentFilesDataBase.Type,filetype);
+        NewFileType::CreateNewDatabaseFileType(SessionManager::instance().CurrentFilesDataBase.Database,SessionManager::instance().CurrentFilesDataBase.Type,filetype);
         int i = ui->FileTypeTable->rowCount();
 //        if(NewFileType.exec()){
             ui->FileTypeTable->insertRow(i);
@@ -1039,7 +1040,7 @@ void DataTables::on_RemFileTypeButton_clicked()
 
 void DataTables::on_EditFileTypeButton_clicked()
 {
-    DataTex::FunctionInProgress();
+    SessionManager::instance().FunctionInProgress();
 //    int row = ui->ExerciseTypeTable->currentRow();
 //    QStringList line;
 //    line.append(ui->ExerciseTypeTable->item(row, 0)->text());

--- a/datatex/edithistory.cpp
+++ b/datatex/edithistory.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "edithistory.h"
 #include "ui_edithistory.h"
 #include <QSqlQuery>
@@ -25,7 +26,7 @@ EditHistory::EditHistory(QWidget *parent, QString filePath, QString buildCommand
     QDir datatexdir(QFileInfo(DatabaseFile).absolutePath()+QDir::separator()+"temp_history"+QDir::separator());
     datatexdir.mkpath(".");
 
-    currentdatabase = (isDocument) ? DataTex::CurrentDocumentsDataBase.Database : DataTex::CurrentFilesDataBase.Database ;
+    currentdatabase = (isDocument) ? SessionManager::instance().CurrentDocumentsDataBase.Database : SessionManager::instance().CurrentFilesDataBase.Database ;
     QSqlQuery data(currentdatabase);
     data.exec(QString("SELECT Date_Time,Modification,FileContent,Metadata FROM Edit_History WHERE File_Id = '%1'")
                   .arg(QFileInfo(DatabaseFile).baseName()));
@@ -67,7 +68,7 @@ EditHistory::EditHistory(QWidget *parent, QString filePath, QString buildCommand
     });
     connect(ui->Complile,&QPushButton::clicked,this,[=](){
         FileCommands::CreateTexFile(temp_file,0,"");
-        FileCommands::BuildDocument(DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX],temp_file);//CurrentBuildCommand
+        FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX],temp_file);//CurrentBuildCommand
         FileCommands::ClearOldFiles(temp_file);
         FileCommands::ShowPdfInViewer(temp_file,TempFileView);
     });

--- a/datatex/encryptdatabase.cpp
+++ b/datatex/encryptdatabase.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "encryptdatabase.h"
 #include "ui_encryptdatabase.h"
 #include "datatex.h"
@@ -14,7 +15,7 @@ EncryptDatabase::EncryptDatabase(QWidget *parent,DTXDatabase database) :
     for(int i=0;i<DatabaseTypes.count();i++){
         ui->DBTypeCombo->addItem(DatabaseTypes[i],i);
     }
-    for(DTXDatabase &db : DataTex::GlobalDatabaseList.values()){
+    for(DTXDatabase &db : SessionManager::instance().GlobalDatabaseList.values()){
         if(db.Type == database.Type){
             ui->DBNameCombo->addItem(db.Description,db.BaseName);
         }
@@ -23,7 +24,7 @@ EncryptDatabase::EncryptDatabase(QWidget *parent,DTXDatabase database) :
     ui->DBNameCombo->model()->sort(0);
     connect(ui->DBTypeCombo,QOverload<int>::of(&QComboBox::activated),this,[=](int index){
         ui->DBNameCombo->clear();
-        for(DTXDatabase &db : DataTex::GlobalDatabaseList.values()){
+        for(DTXDatabase &db : SessionManager::instance().GlobalDatabaseList.values()){
             if(db.Type == index){
                 ui->DBNameCombo->addItem(db.Description);
             }
@@ -48,11 +49,11 @@ EncryptDatabase::EncryptDatabase(QWidget *parent,DTXDatabase database) :
     connect(ui->OkButton,&QDialogButtonBox::accepted,this,[&](){
         QString db = ui->DBNameCombo->currentData().toString();
 
-        DataTex::GlobalDatabaseList[db].Username = ui->UsernameLine->text();
+        SessionManager::instance().GlobalDatabaseList[db].Username = ui->UsernameLine->text();
         const QByteArray password = ui->PasswordLine->text().toUtf8();
         QString HashedPassword = QCryptographicHash::hash(password,QCryptographicHash::Sha256);
-        DataTex::GlobalDatabaseList[db].Password = HashedPassword;//Κρυπτογράφηση
-        QSqlQuery fdb_encription;//(DataTex::DataTeX_Settings);
+        SessionManager::instance().GlobalDatabaseList[db].Password = HashedPassword;//Κρυπτογράφηση
+        QSqlQuery fdb_encription;//(SessionManager::instance().DataTeX_Settings);
         fdb_encription.exec(QString("UPDATE DataBases SET UserName = '%1' WHERE FileName = '%2'")
                                 .arg(ui->UsernameLine->text(),db));
         fdb_encription.exec(QString("UPDATE DataBases SET PassWord = '%1' WHERE FileName = '%2'")

--- a/datatex/filecommands.cpp
+++ b/datatex/filecommands.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "filecommands.h"
 #include <QRegExp>
 
@@ -114,7 +115,7 @@ DTXFile::DTXFile(QString fileId,QSqlDatabase database){
     BuildCommand = meta[7];
     Description = meta[8];
     Database.Id = database.databaseName();
-    DatabaseId = DataTex::GlobalDatabaseList.value(QFileInfo(database.databaseName()).baseName()).Description;
+    DatabaseId = SessionManager::instance().GlobalDatabaseList.value(QFileInfo(database.databaseName()).baseName()).Description;
     Tags = SqlFunctions::Get_StringList_From_Query(QString("SELECT Tag_Id FROM "
                                                            "Tags_per_File WHERE File_Id = '%1'").arg(fileId),database);
     Solutions = SqlFunctions::Get_StringList_From_Query(QString("SELECT Solution_Id FROM "
@@ -457,7 +458,7 @@ DTXDocument::DTXDocument(QString docId,QSqlDatabase database){
     Description = meta[13];
     SolutionDocument = meta[14];
 //    Database = database;
-    DatabaseName = DataTex::GlobalDatabaseList.value(QFileInfo(database.databaseName()).baseName()).Description;
+    DatabaseName = SessionManager::instance().GlobalDatabaseList.value(QFileInfo(database.databaseName()).baseName()).Description;
     Tags = QStringList();
     FilesIncluded = QList<DTXIncludedFile>();
     BibEntries = QStringList();
@@ -505,7 +506,7 @@ DTXDocument::DTXDocument(QString DTexPath)
             Line = Line.chopped(1);
             QStringList list = Line.split(",");
             DatabaseName = list[1];
-            //            Database = DataTex::GlobalDatabaseList.value(list[0]).Database;
+            //            Database = SessionManager::instance().GlobalDatabaseList.value(list[0]).Database;
         }
         if(Line.startsWith("Id=")){
             Line = Line.remove("Id=");
@@ -649,7 +650,7 @@ QString FileCommands::CreateTexFile(QString fullFilePath,bool addToPreamble,QStr
     QString outputFile = QFileInfo(fullFilePath).baseName();
     QString realContent = QString();
 
-    QString sheetFileContent = DataTex::CurrentPreamble_Content+ "\n";
+    QString sheetFileContent = SessionManager::instance().CurrentPreamble_Content+ "\n";
     sheetFileContent += (addToPreamble) ? addStuffToPreamble : QString();
     sheetFileContent += "\n\\begin{document}\n";
     QFile Databasefile(fullFilePath);
@@ -729,7 +730,7 @@ void FileCommands::ShowPdfInViewer(QString exoFile, QPdfViewer *view)
         view->open(QUrl(pdfFile));
     }
     else{
-        view->open(QUrl("file://"+DataTex::datatexpath+"No_Pdf.pdf"));
+        view->open(QUrl("file://"+SessionManager::instance().datatexpath+"No_Pdf.pdf"));
     }
     // qDebug()<<exoFile;
 }
@@ -738,7 +739,7 @@ QString FileCommands::NewFileText(QString fileName,QString FileContent)
 {
     QString text;
     text = "%# File Id : "+QFileInfo(fileName).baseName()+"\n";
-    text += "%@ FilesDB Id : "+QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName()+"\n";
+    text += "%@ FilesDB Id : "+QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName()+"\n";
     text += FileContent+"\n";
     text += "%# End of file "+QFileInfo(fileName).baseName();
     return text;
@@ -877,13 +878,13 @@ QString FileCommands::NewFilePathAndId(DTXFile *info,bool needsSubSection)
     QString ChapterId = info->getIds(info->Chapters).join("");
     QString SectionId = info->getIds(info->Sections).join("");
     QString SubSectionId = info->getIds(info->SubSections).join("");
-    QString Path = QFileInfo(DataTex::CurrentFilesDataBase.Path).absolutePath()+QDir::separator()+info->Field.Name+QDir::separator()+Chapters+QDir::separator()+Sections+QDir::separator()+info->FileType.FolderName+QDir::separator();
-    QString prefix;// = SqlFunctions::Get_String_From_Query(QString("SELECT Prefix FROM DataBases WHERE FileName = '%1'").arg(QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName()),DataTex::DataTeX_Settings);
+    QString Path = QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).absolutePath()+QDir::separator()+info->Field.Name+QDir::separator()+Chapters+QDir::separator()+Sections+QDir::separator()+info->FileType.FolderName+QDir::separator();
+    QString prefix;// = SqlFunctions::Get_String_From_Query(QString("SELECT Prefix FROM DataBases WHERE FileName = '%1'").arg(QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName()),SessionManager::instance().DataTeX_Settings);
     prefix = (!prefix.isEmpty() && !prefix.isNull()) ? prefix+"-" : QString() ;
     QString fileId = (needsSubSection) ? prefix+info->Field.Id+"-"+ChapterId+"-"+SectionId+"-"+SubSectionId+"-"+info->FileType.Id
                                        : prefix+info->Field.Id+"-"+ChapterId+"-"+SectionId+"-"+info->FileType.Id;
     QStringList ExistingFiles = SqlFunctions::Get_StringList_From_Query(
-        QString("SELECT Id FROM Database_Files WHERE Id LIKE \"%%1%\"").arg(fileId),DataTex::CurrentFilesDataBase.Database);
+        QString("SELECT Id FROM Database_Files WHERE Id LIKE \"%%1%\"").arg(fileId),SessionManager::instance().CurrentFilesDataBase.Database);
     int fileNumber = 1;
     while(ExistingFiles.contains(fileId+QString::number(fileNumber))){
         fileNumber++;
@@ -970,7 +971,7 @@ void FileCommands::AddNewFileToDatabase(DTXFile * fileInfo,QSqlDatabase database
     }
 
     // Write metadata to dtex and csv files
-    CsvFunctions::WriteDataToCSV(fileInfo->Path,DataTex::CurrentFilesDataBase.Database);
+    CsvFunctions::WriteDataToCSV(fileInfo->Path,SessionManager::instance().CurrentFilesDataBase.Database);
     fileInfo->WriteDTexFile();
 
 //    QSqlQuery insertTag(database);

--- a/datatex/graphicsbuilder.cpp
+++ b/datatex/graphicsbuilder.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "graphicsbuilder.h"
 #include "ui_graphicsbuilder.h"
 
@@ -6,7 +7,7 @@ GraphicsBuilder::GraphicsBuilder(QWidget *parent) :
     ui(new Ui::GraphicsBuilder)
 {
     ui->setupUi(this);
-    QList<QStringList> pst_packages;// = SqlFunctions::GetRecordList("SELECT * FROM Pstricks_Packages WHERE rowid>4",DataTex::DataTeX_Settings);
+    QList<QStringList> pst_packages;// = SqlFunctions::GetRecordList("SELECT * FROM Pstricks_Packages WHERE rowid>4",SessionManager::instance().DataTeX_Settings);
     for (int i = 0; i < pst_packages.count(); ++i) {
         QTreeWidgetItem * item = new QTreeWidgetItem(pst_packages[i]);
         ui->PstTree->topLevelItem(3)->addChild(item);

--- a/datatex/latexeditorwidget.cpp
+++ b/datatex/latexeditorwidget.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include <QScrollBar>
 #include <QPainter>
 #include <QAbstractTextDocumentLayout>
@@ -366,14 +367,14 @@ LatexTextWidget::LatexTextWidget(QWidget * parent,bool useMath,bool usePreamble)
         file.close();
         SaveContentToDatabase(QFileInfo(DatabaseFilePath).baseName(),FileContent);
         if(PreviousContent != FileContent){
-            QSqlQuery needsUpdate(DataTex::CurrentDocumentsDataBase.Database);
+            QSqlQuery needsUpdate(SessionManager::instance().CurrentDocumentsDataBase.Database);
             needsUpdate.exec(QString("UPDATE Documents SET NeedsUpdate = 1 WHERE Id IN (SELECT Document_Id FROM Files_per_Document WHERE File_Id = \"%1\")").arg(QFileInfo(DatabaseFilePath).baseName()));
-            QSqlQuery editEntry(DataTex::CurrentFilesDataBase.Database);
+            QSqlQuery editEntry(SessionManager::instance().CurrentFilesDataBase.Database);
             editEntry.exec(QString("INSERT INTO Edit_History (File_Id,Date_Time,Modification,FileContent,Metadata)"
                                    "VALUES ('%1','%2','Content modified',\"%3\",'%4')")
                                .arg(QFileInfo(DatabaseFilePath).baseName(),QDateTime::currentDateTime().toString("dd/M/yyyy hh:mm"),FileContent,""));
         }
-        DTXFile fileInfo = DTXFile(QFileInfo(DatabaseFilePath).baseName(),DataTex::CurrentFilesDataBase.Database);
+        DTXFile fileInfo = DTXFile(QFileInfo(DatabaseFilePath).baseName(),SessionManager::instance().CurrentFilesDataBase.Database);
         // qDebug()<<"fileId = "<<fileInfo.Difficulty;
         fileInfo.WriteDTexFile();
     });
@@ -432,13 +433,13 @@ void LatexTextWidget::setup()
 
 void LatexTextWidget::SaveContentToDatabase(QString fileName, QString content)
 {
-    QSqlQuery WriteContent(DataTex::CurrentFilesDataBase.Database);
+    QSqlQuery WriteContent(SessionManager::instance().CurrentFilesDataBase.Database);
     WriteContent.prepare("UPDATE Database_Files SET FileContent = :content WHERE Id = :file");
     WriteContent.bindValue(":file",QFileInfo(fileName).baseName());
     WriteContent.bindValue(":content",content);
     WriteContent.exec();
 
-    QSqlQuery WriteContent_2(DataTex::CurrentDocumentsDataBase.Database);
+    QSqlQuery WriteContent_2(SessionManager::instance().CurrentDocumentsDataBase.Database);
     WriteContent_2.prepare("UPDATE Documents SET Content = :content WHERE Id = :file");
     WriteContent_2.bindValue(":file",QFileInfo(fileName).baseName());
     WriteContent_2.bindValue(":content",content);

--- a/datatex/latextoolbar.cpp
+++ b/datatex/latextoolbar.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "latextoolbar.h"
 
 LatexToolBar::LatexToolBar(QWidget *parent)
@@ -350,7 +351,7 @@ MathToolBar::MathToolBar(QWidget *parent)
 //        Files.append(list.next());
 //    }
 //    Files.sort();
-    for (QString svgPath: /*Files*/DataTex::SVG_IconPaths) {
+    for (QString svgPath: /*Files*/SessionManager::instance().SVG_IconPaths) {
         SymbolItem symbol;
         symbol.iconFile = svgPath;
         QFile file(symbol.iconFile);

--- a/datatex/newdatabasefile.cpp
+++ b/datatex/newdatabasefile.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "newdatabasefile.h"
 #include "ui_newdatabasefile.h"
 #include <QTabWidget>
@@ -43,7 +44,7 @@ NewDatabaseFile::NewDatabaseFile(QWidget *parent, DTXFile *fileinfo, int mode) :
     ui->removeChapter->setEnabled(false);
     ui->removeSection->setEnabled(false);
     ui->removeSubSection->setEnabled(false);
-    currentbase = DataTex::CurrentFilesDataBase.Database;
+    currentbase = SessionManager::instance().CurrentFilesDataBase.Database;
     DataBase_Path = QFileInfo(currentbase.databaseName()).absolutePath()+QDir::separator();
     if(mode==0){
         metadata = new DTXFile;
@@ -75,9 +76,9 @@ NewDatabaseFile::NewDatabaseFile(QWidget *parent, DTXFile *fileinfo, int mode) :
     tagLine->setEnabled(false);
     ui->SaveSelectionsCheckBox->setEnabled(false);
     ui->NewFileContentText->toolBar->Save->setVisible(false);
-    // QStringList PreambleIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Preambles ORDER BY ROWID",DataTex::DataTeX_Settings);
-    // QStringList PreambleNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Preambles",DataTex::DataTeX_Settings);
-    for(const DTXBuildCommand &build : qAsConst(DataTex::DTXBuildCommands)){
+    // QStringList PreambleIds = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM Preambles ORDER BY ROWID",SessionManager::instance().DataTeX_Settings);
+    // QStringList PreambleNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM Preambles",SessionManager::instance().DataTeX_Settings);
+    for(const DTXBuildCommand &build : qAsConst(SessionManager::instance().DTXBuildCommands)){
         ui->BuildBox->addItem(build.Name,QVariant::fromValue(build));
     }
     DTXSettings dtxsettings;
@@ -167,7 +168,7 @@ NewDatabaseFile::NewDatabaseFile(QWidget *parent, DTXFile *fileinfo, int mode) :
         }
     });
 
-    metadata->Database.setDBInfo(DataTex::CurrentFilesDataBase);
+    metadata->Database.setDBInfo(SessionManager::instance().CurrentFilesDataBase);
 }
 
 NewDatabaseFile::~NewDatabaseFile()
@@ -283,7 +284,7 @@ void NewDatabaseFile::CloneModeIsEnabled(int cloneMode)
     metadata->Path = FileCommands::NewFilePathAndId(metadata,/*needsSubSection*/true);
     metadata->Id = QFileInfo(metadata->Path).baseName();
     metadata->Content = FileCommands::ClearMetadataFromContent(metadata->Content);
-    ui->NewFileContentText->editor->setText(FileCommands::NewFileText(metadata->Id,metadata->Content,DataTex::CurrentFilesDataBase.Database));
+    ui->NewFileContentText->editor->setText(FileCommands::NewFileText(metadata->Id,metadata->Content,SessionManager::instance().CurrentFilesDataBase.Database));
 }
 
 void NewDatabaseFile::CloneModeIsEnabled(DTXFile * fileInfo,bool cloneMetadata)
@@ -540,7 +541,7 @@ void NewDatabaseFile::on_addFileType_clicked()
         ui->gridLayout_10->addWidget(newButton,ui->gridLayout_10->rowCount(),0);
 //        ui->gridLayout_10->addItem(ui->gridLayout_8,ui->gridLayout_10->rowCount(),0);
         ui->gridLayout_10->addItem(ui->verticalSpacer_2,ui->gridLayout_10->rowCount(),0);
-        NewFileType::CreateNewDatabaseFileType(DataTex::CurrentFilesDataBase.Database,DataTex::CurrentFilesDataBase.Type,data);
+        NewFileType::CreateNewDatabaseFileType(SessionManager::instance().CurrentFilesDataBase.Database,SessionManager::instance().CurrentFilesDataBase.Type,data);
     });
     newFile->show();
     newFile->activateWindow();
@@ -636,7 +637,7 @@ void NewDatabaseFile::FieldsClicked(QListWidgetItem * item)
         QCompleter *completer = new QCompleter(Chapter_Names, this);
         completer->setCaseSensitivity(Qt::CaseInsensitive);
         ui->FilterChapters->setCompleter(completer);
-        DataTex::StretchColumnsToWidth(ui->ExerciseFileList);
+        SessionManager::instance().StretchColumnsToWidth(ui->ExerciseFileList);
         ui->ExerciseFileList->setColumnHidden(2,true);
 
         // ui->removeChapter->setEnabled(true);
@@ -806,7 +807,7 @@ void NewDatabaseFile::NewFilePathAndId()
     QString ChapterId = Selected_Chapters_ids.values().join("");
     QString SectionId = Selected_Sections_ids.values().join("");
     QString Path = DataBase_Path+Field+QDir::separator()+Chapter+QDir::separator()+Section+QDir::separator()+subSection+QDir::separator()+FileType.FolderName+QDir::separator();
-    QString prefix;// = SqlFunctions::Get_String_From_Query(QString("SELECT Prefix FROM DataBases WHERE FileName = '%1'").arg(QFileInfo(currentbase.databaseName()).baseName()),DataTex::DataTeX_Settings);
+    QString prefix;// = SqlFunctions::Get_String_From_Query(QString("SELECT Prefix FROM DataBases WHERE FileName = '%1'").arg(QFileInfo(currentbase.databaseName()).baseName()),SessionManager::instance().DataTeX_Settings);
     prefix = (!prefix.isEmpty() && !prefix.isNull()) ? prefix+"-" : QString();
     QString fileId = prefix+FieldId+"-"+ChapterId+"-"+SectionId+"-"+FileType.Id;
     QStringList ExistingFiles = SqlFunctions::Get_StringList_From_Query(
@@ -844,7 +845,7 @@ QList<QListWidgetItem *> NewDatabaseFile::FindListItemByData(QListWidget *list,Q
 void NewDatabaseFile::LoadFileTypes()
 {
     ui->gridLayout_10->removeItem(ui->verticalSpacer_2);
-    for(DTXFileType filetype : qAsConst(DataTex::CurrentFilesDataBase.FileTypes)){
+    for(DTXFileType filetype : qAsConst(SessionManager::instance().CurrentFilesDataBase.FileTypes)){
         if(filetype.Solvable != DTXSolutionState::Solution){
             QRadioButton * button = new QRadioButton(filetype.Name,this);
             button->setProperty("Id",QVariant::fromValue(filetype));
@@ -863,12 +864,12 @@ void NewDatabaseFile::InitialSettings()
 {
     QSettings settings;
     settings.beginGroup("NewDatabaseFile");
-    QString fileType = settings.value("NewDatabaseFile_CurrentFileType").toString();//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentFileType'",DataTex::DataTeX_Settings);
-    QString field = settings.value("NewDatabaseFile_CurrentField").toString();//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentField'",DataTex::DataTeX_Settings);
+    QString fileType = settings.value("NewDatabaseFile_CurrentFileType").toString();//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentFileType'",SessionManager::instance().DataTeX_Settings);
+    QString field = settings.value("NewDatabaseFile_CurrentField").toString();//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentField'",SessionManager::instance().DataTeX_Settings);
     QStringList chapters =
-        settings.value("NewDatabaseFile_CurrentChapter").toString().split(",");//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentChapter'",DataTex::DataTeX_Settings).split(",");
-    QStringList sections = settings.value("NewDatabaseFile_CurrentSection").toString().split(",");//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentSection'",DataTex::DataTeX_Settings).split(",");
-    QStringList subsections = settings.value("NewDatabaseFile_ExerciseType").toString().split(",");//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_ExerciseType'",DataTex::DataTeX_Settings).split(",");
+        settings.value("NewDatabaseFile_CurrentChapter").toString().split(",");//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentChapter'",SessionManager::instance().DataTeX_Settings).split(",");
+    QStringList sections = settings.value("NewDatabaseFile_CurrentSection").toString().split(",");//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_CurrentSection'",SessionManager::instance().DataTeX_Settings).split(",");
+    QStringList subsections = settings.value("NewDatabaseFile_ExerciseType").toString().split(",");//SqlFunctions::Get_String_From_Query("SELECT Value FROM Initial_Settings WHERE Setting = 'NewDatabaseFile_ExerciseType'",SessionManager::instance().DataTeX_Settings).split(",");
     settings.endGroup();
     for (int i=0;i<FileTypeGroup->buttons().count();i++) {
         if(FileTypeGroup->buttons().at(i)->property("Id").value<DTXFileType>().Id == fileType){
@@ -910,15 +911,15 @@ void NewDatabaseFile::InitialSettings()
 
 void NewDatabaseFile::SaveSettings()
 {
-    QSqlQuery SaveSelections;//(DataTex::DataTeX_Settings);
-//    QProcess::execute("chmod",{"777",DataTex::getDataTexPath()});
+    QSqlQuery SaveSelections;//(SessionManager::instance().DataTeX_Settings);
+//    QProcess::execute("chmod",{"777",SessionManager::instance().getDataTexPath()});
     SaveSelections.exec("UPDATE Initial_Settings SET Value = '"+QString::number(ui->SaveSelectionsCheckBox->isChecked())+"' WHERE Setting = 'SaveNewFileSelections'");
     SaveSelections.exec("UPDATE Initial_Settings SET Value = '"+FileType.Id+"' WHERE Setting = 'NewDatabaseFile_CurrentFileType'");
     SaveSelections.exec("UPDATE Initial_Settings SET Value = '"+ui->FieldTable->currentItem()->data(Qt::UserRole).toString()+"' WHERE Setting = 'NewDatabaseFile_CurrentField'");
     SaveSelections.exec("UPDATE Initial_Settings SET Value = '"+Selected_Chapters_ids.values().join(",")+"' WHERE Setting = 'NewDatabaseFile_CurrentChapter'");
     SaveSelections.exec("UPDATE Initial_Settings SET Value = '"+Selected_Sections_ids.values().join(",")+"' WHERE Setting = 'NewDatabaseFile_CurrentSection'");
     SaveSelections.exec("UPDATE Initial_Settings SET Value = '"+Selected_SubSections_ids.values().join(",")+"' WHERE Setting = 'NewDatabaseFile_ExerciseType'");
-//    QProcess::execute("chmod",{"555",DataTex::getDataTexPath()});
+//    QProcess::execute("chmod",{"555",SessionManager::instance().getDataTexPath()});
 }
 
 void NewDatabaseFile::hideButton(bool setHidden)
@@ -951,7 +952,7 @@ void NewDatabaseFile::setDBFileInfo()
     }
     metadata->Bibliography = QString();
     metadata->Content = FileCommands::ClearMetadataFromContent(FileContent);
-    metadata->Content = FileCommands::NewFileText(metadata->Id,metadata->Content,DataTex::CurrentFilesDataBase.Database);
+    metadata->Content = FileCommands::NewFileText(metadata->Id,metadata->Content,SessionManager::instance().CurrentFilesDataBase.Database);
     metadata->Preamble.Id = ui->PreambleBox->currentData().toString();
     metadata->BuildCommand = ui->BuildBox->currentText();
     metadata->Description = ui->DescriptionLine->toPlainText();

--- a/datatex/newfiletype.cpp
+++ b/datatex/newfiletype.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "newfiletype.h"
 #include "ui_newfiletype.h"
 #include <QRegularExpression>
@@ -11,9 +12,9 @@ NewFileType::NewFileType(QWidget *parent,DTXDatabaseType Type) :
 {
     ui->setupUi(this);
     DBType = Type;
-    QStringList Ids = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM FileTypes",DataTex::CurrentFilesDataBase.Database);
-    QStringList Names = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM FileTypes",DataTex::CurrentFilesDataBase.Database);
-    QStringList Folders = SqlFunctions::Get_StringList_From_Query("SELECT FolderName FROM FileTypes",DataTex::CurrentFilesDataBase.Database);
+    QStringList Ids = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM FileTypes",SessionManager::instance().CurrentFilesDataBase.Database);
+    QStringList Names = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM FileTypes",SessionManager::instance().CurrentFilesDataBase.Database);
+    QStringList Folders = SqlFunctions::Get_StringList_From_Query("SELECT FolderName FROM FileTypes",SessionManager::instance().CurrentFilesDataBase.Database);
     setWindowTitle("Select a name/desctription for tis database");
     QRegularExpression pk("[A-Za-z0-9]{1,}");
     QRegularExpressionValidator * validator = new QRegularExpressionValidator( pk, this );

--- a/datatex/notesdocuments.cpp
+++ b/datatex/notesdocuments.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "notesdocuments.h"
 #include "dtxsettings.h"
 #include "ui_notesdocuments.h"
@@ -9,9 +10,9 @@ NotesDocuments::NotesDocuments(QWidget *parent, DTXDocument document, int mode) 
     ui(new Ui::NotesDocuments)
 {
     radiogroup = new QButtonGroup;
-    currentbase = DataTex::CurrentDocumentsDataBase;
-    currentbase_Exercises = DataTex::CurrentFilesDataBase;
-    DocumentsPath = QFileInfo(DataTex::CurrentDocumentsDataBase.Path).absolutePath()+QDir::separator();
+    currentbase = SessionManager::instance().CurrentDocumentsDataBase;
+    currentbase_Exercises = SessionManager::instance().CurrentFilesDataBase;
+    DocumentsPath = QFileInfo(SessionManager::instance().CurrentDocumentsDataBase.Path).absolutePath()+QDir::separator();
     Document = document;
     Mode = mode;
     CurrentDocContent = FileCommands::ClearDocumentContent(Document.Content);
@@ -44,8 +45,8 @@ NotesDocuments::NotesDocuments(QWidget *parent, DTXDocument document, int mode) 
     level = -1;
 
     DTXSettings dtxsettings;
-    QList<QStringList> Preambles = dtxsettings.getCurrentPreambleInfo();//SqlFunctions::GetRecordList("SELECT Id,Name FROM Preambles ORDER BY ROWID",DataTex::DataTeX_Settings);
-    for(const DTXBuildCommand &build : qAsConst(DataTex::DTXBuildCommands)){
+    QList<QStringList> Preambles = dtxsettings.getCurrentPreambleInfo();//SqlFunctions::GetRecordList("SELECT Id,Name FROM Preambles ORDER BY ROWID",SessionManager::instance().DataTeX_Settings);
+    for(const DTXBuildCommand &build : qAsConst(SessionManager::instance().DTXBuildCommands)){
         ui->BuildBox->addItem(build.Name,QVariant::fromValue(build));
     }
     for (int i=0;i<Preambles.count();i++) {
@@ -81,11 +82,11 @@ NotesDocuments::NotesDocuments(QWidget *parent, DTXDocument document, int mode) 
     ui->verticalLayout_20->addWidget(tagLine);
     tags = tagLine->GetTags();
     tagLine->setEnabled(false);
-    DataTex::StretchColumnsToWidth(DocumentTable);
+    SessionManager::instance().StretchColumnsToWidth(DocumentTable);
     if(mode == CloneModeContentAndMetadata || mode == CloneModeOnlyContent){
         ui->DatabaseCombo->addItem(tr("Select a database..."));
-        for (DTXDatabase DTXDB : DataTex::GlobalDatabaseList) {
-            if(DTXDB.Path!=DataTex::CurrentDocumentsDataBase.Path && DTXDB.Type == DTXDatabaseType::DocumentsDB){
+        for (DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList) {
+            if(DTXDB.Path!=SessionManager::instance().CurrentDocumentsDataBase.Path && DTXDB.Type == DTXDatabaseType::DocumentsDB){
                 ui->DatabaseCombo->addItem(DTXDB.Description,DTXDB.Path);
             }
         }
@@ -97,12 +98,12 @@ NotesDocuments::NotesDocuments(QWidget *parent, DTXDocument document, int mode) 
         ui->DatabaseLabel->setVisible(false);
     }
     RandomFilesToKeep = 0;
-    for (DTXDatabase DTXDB : DataTex::GlobalDatabaseList) {
+    for (DTXDatabase DTXDB : SessionManager::instance().GlobalDatabaseList) {
         if(DTXDB.Type == DTXDatabaseType::FilesDB){
             ui->FilesDatabasesCombo->addItem(DTXDB.Description,QVariant::fromValue(DTXDB));
         }
     }
-    ui->FilesDatabasesCombo->setCurrentText(DataTex::CurrentFilesDataBase.Description);
+    ui->FilesDatabasesCombo->setCurrentText(SessionManager::instance().CurrentFilesDataBase.Description);
 
     FilesTable = new ExtendedTableWidget(this);
     ui->gridLayout_16->addWidget(FilesTable,3,0,1,1);
@@ -111,11 +112,11 @@ NotesDocuments::NotesDocuments(QWidget *parent, DTXDocument document, int mode) 
     FilesTable->horizontalHeader()->setSectionsClickable(true);
     FilesTable->setAlternatingRowColors(true);
 
-    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp WHERE Table_Id = 'Metadata'",DataTex::CurrentFilesDataBase.Database);
-    Database_FileTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE Table_Id = 'Metadata'",DataTex::CurrentFilesDataBase.Database);
-    LoadDatabaseFiles(DataTex::CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
+    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp WHERE Table_Id = 'Metadata'",SessionManager::instance().CurrentFilesDataBase.Database);
+    Database_FileTableFieldNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE Table_Id = 'Metadata'",SessionManager::instance().CurrentFilesDataBase.Database);
+    LoadDatabaseFiles(SessionManager::instance().CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
     ui->numOfFilesSpin->setMaximum(CountModelRows());
-    DataTex::StretchColumns(FilesTable,1.5);
+    SessionManager::instance().StretchColumns(FilesTable,1.5);
 
     ui->splitter->setSizes(QList<int>({1,200}));
     ui->splitter_2->setSizes(QList<int>({1,300}));
@@ -273,15 +274,15 @@ NotesDocuments::~NotesDocuments()
 void NotesDocuments::updateFilter(QStringList values)
 {
     SqlFunctions::FilterDatabaseDocuments.clear();
-    DataTex::FilterDocuments(Database_DocumentTableColumns);
+    SessionManager::instance().FilterDocuments(Database_DocumentTableColumns);
     int columns = Database_DocumentTableColumns.count();
     for (int i=0;i<columns;i++) {
         SqlFunctions::FilterDatabaseDocuments.replace("replace"+Database_DocumentTableColumns.at(i),values.at(i));
     }
-    DataTex::updateTableView(DocumentTable,SqlFunctions::FilterDatabaseDocuments,currentbase.Database,this);
+    SessionManager::instance().updateTableView(DocumentTable,SqlFunctions::FilterDatabaseDocuments,currentbase.Database,this);
     connect(DocumentTable->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &NotesDocuments::DocumentTable_selectionChanged);
-    DataTex::LoadTableHeaders(DocumentTable,Database_DocumentTableColumns);
+    SessionManager::instance().LoadTableHeaders(DocumentTable,Database_DocumentTableColumns);
 }
 
 void NotesDocuments::DocumentTable_selectionChanged()
@@ -592,14 +593,14 @@ void NotesDocuments::on_OpenPath_clicked()
 
 void NotesDocuments::on_DatabaseCombo_activated(int index)
 {
-//    qDebug()<<DataTex::GlobalDatabaseList;
+//    qDebug()<<SessionManager::instance().GlobalDatabaseList;
     QString database = QFileInfo(ui->DatabaseCombo->currentData().toString()).baseName();
-    currentbase = DataTex::GlobalDatabaseList.value(database);
+    currentbase = SessionManager::instance().GlobalDatabaseList.value(database);
     DocumentsPath = QFileInfo(currentbase.Path).absolutePath()+QDir::separator();
     GetDocTypes();
     LoadFolderStructure();
     LoadDocTable();
-//    qDebug()<<DataTex::GlobalDatabaseList;
+//    qDebug()<<SessionManager::instance().GlobalDatabaseList;
 }
 
 void NotesDocuments::GetDocTypes()
@@ -670,7 +671,7 @@ void NotesDocuments::LoadDocTable()
     DocumentTable->generateFilters(columns,false);
     connect(DocumentTable->selectionModel(), &QItemSelectionModel::selectionChanged,this, &NotesDocuments::DocumentTable_selectionChanged);
     connect(DocumentTable->filterHeader(), &FilterTableHeader::filterValues, this, &NotesDocuments::updateFilter);
-    DataTex::StretchColumns(DocumentTable,1.5);
+    SessionManager::instance().StretchColumns(DocumentTable,1.5);
     for (int i=2;i<DocumentTable->model()->columnCount();i++) {
         DocumentTable->setColumnHidden(i,true);
     }
@@ -683,7 +684,7 @@ void NotesDocuments::LoadDatabaseFiles(QSqlDatabase database,QString query)
     FilesTable->generateFilters(columns,false);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,this, &NotesDocuments::FilesTable_selectionchanged);
     connect(FilesTable->filterHeader(), &FilterTableHeader::filterValues, this, &NotesDocuments::updateFilter_files);
-    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
 }
 
 void NotesDocuments::on_RandomSelectionList_itemSelectionChanged()
@@ -779,11 +780,11 @@ void NotesDocuments::updateFilter_files(QStringList values)
     SqlFunctions::FilterTable(Database_FileTableFields,values);
     int columns = Database_FileTableFields.count();
     FilesTable->setColumnHidden(columns,true);
-    DataTex::updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,currentbase_Exercises.Database,this);
+    SessionManager::instance().updateTableView(FilesTable,SqlFunctions::FilesTable_UpdateQuery,currentbase_Exercises.Database,this);
     FilesTable->filterTable(SqlFunctions::FilesTable_UpdateQuery,currentbase_Exercises.Database,filesSorting);
     connect(FilesTable->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &NotesDocuments::FilesTable_selectionchanged);
-    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
     ui->numOfFilesSpin->setMaximum(CountModelRows());
 }
 
@@ -802,7 +803,7 @@ void NotesDocuments::FilesTable_selectionchanged()
     QString pdffile = file.replace(".tex",".pdf");
     if(!QFileInfo::exists(pdffile)){
         //        FileCommands::CreateTexFile(PreviewFile,0,""/*preamble*/);
-        //        FileCommands::BuildDocument(DataTex::DTXBuildCommands[buildCommand],PreviewFile,DataTex::LatexCommandsArguments[buildCommand],".tex");
+        //        FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[buildCommand],PreviewFile,SessionManager::instance().LatexCommandsArguments[buildCommand],".tex");
         //        FileCommands::ClearOldFiles(PreviewFile);
         //Need to add a 'preamble' variable in CreateTexFile command
     }
@@ -860,13 +861,13 @@ void NotesDocuments::SelectedFilesInDocument()
     DatabasesInsideDocument.removeDuplicates();
     QString files = "(\""+FilesInsideDocument.join("\",\"")+"\")";
     QSqlQueryModel * FilesModel = new QSqlQueryModel(this);
-    QStringList DataQueries;// = {SqlFunctions::ShowFilesInADocument.arg(files,QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName())};
-    QSqlQuery FilesQuery(DataTex::CurrentFilesDataBase.Database);
+    QStringList DataQueries;// = {SqlFunctions::ShowFilesInADocument.arg(files,QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName())};
+    QSqlQuery FilesQuery(SessionManager::instance().CurrentFilesDataBase.Database);
     for (QString databaseId : DatabasesInsideDocument) {
-        DTXDatabase DTXDB = DataTex::GlobalDatabaseList.value(databaseId);
-        QString name = (DTXDB.Path!=DataTex::CurrentFilesDataBase.Path) ? DTXDB.BaseName : "main" ;
+        DTXDatabase DTXDB = SessionManager::instance().GlobalDatabaseList.value(databaseId);
+        QString name = (DTXDB.Path!=SessionManager::instance().CurrentFilesDataBase.Path) ? DTXDB.BaseName : "main" ;
         DataQueries.append(SqlFunctions::ShowFilesInADocument.arg(files,DTXDB.BaseName,name));
-        if(DTXDB.Path!=DataTex::CurrentFilesDataBase.Path) {
+        if(DTXDB.Path!=SessionManager::instance().CurrentFilesDataBase.Path) {
             FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(DTXDB.Path,DTXDB.BaseName));
         }
     }
@@ -878,7 +879,7 @@ void NotesDocuments::SelectedFilesInDocument()
     ui->filesSelected->show();
     connect(ui->filesSelected->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &NotesDocuments::filesSelected_SelectionChanged);
-    DataTex::StretchColumns(ui->filesSelected,1.5);
+    SessionManager::instance().StretchColumns(ui->filesSelected,1.5);
 }
 
 void NotesDocuments::on_RefreshSelection_clicked()
@@ -961,7 +962,7 @@ void NotesDocuments::on_checkBox_clicked(bool checked)
     }
     else {
         ui->FilesDatabasesCombo->setEnabled(checked);
-        LoadDatabaseFiles(DataTex::CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
+        LoadDatabaseFiles(SessionManager::instance().CurrentFilesDataBase.Database,SqlFunctions::ShowAllDatabaseFiles);
         FilesTable->filterHeader()->adjustPositions();
     }
 }

--- a/datatex/preamblesettings.cpp
+++ b/datatex/preamblesettings.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "preamblesettings.h"
 #include "qregexp.h"
 #include "ui_preamblesettings.h"
@@ -48,7 +49,7 @@ PreambleSettings::PreambleSettings(QWidget *parent,QString preamble_content) :
 {
     ui->setupUi(this);
     CTANPackages = QSqlDatabase::addDatabase("QSQLITE","CTANPackages");
-    CTANPackages.setDatabaseName(DataTex::datatexpath+"CTANDatabase.db");
+    CTANPackages.setDatabaseName(SessionManager::instance().datatexpath+"CTANDatabase.db");
     CTANPackages.open();
     PreambleContent = preamble_content;
     for(QAbstractButton * bt:ui->TabButtonGroup->buttons()){
@@ -189,7 +190,7 @@ PreambleSettings::PreambleSettings(QWidget *parent,QString preamble_content) :
     });
 
     ui->TemplateTree->setColumnHidden(1,true);
-    QSqlQuery getTemplates;//(DataTex::DataTeX_Settings);
+    QSqlQuery getTemplates;//(SessionManager::instance().DataTeX_Settings);
     getTemplates.exec("SELECT Name,Preamble_Content,BuiltIn FROM Preambles");
     while(getTemplates.next()){
         QTreeWidgetItem * item = new QTreeWidgetItem();

--- a/datatex/settings.cpp
+++ b/datatex/settings.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "settings.h"
 #include "dtxsettings.h"
 #include "preamblesettings.h"
@@ -11,13 +12,13 @@ Settings::Settings(QWidget *parent)
     ui->setupUi(this);
     QStringList DatabasesFileNames;
     QStringList DatabasesNames;
-    QSqlQuery fields;//(DataTex::DataTeX_Settings);
+    QSqlQuery fields;//(SessionManager::instance().DataTeX_Settings);
     fields.exec("SELECT FileName,Name FROM DataBases");
     while(fields.next()){
         DatabasesFileNames.append(fields.value(0).toString());
         DatabasesNames.append(fields.value(1).toString());
     }
-    QSqlQuery currentBase;//(DataTex::DataTeX_Settings);
+    QSqlQuery currentBase;//(SessionManager::instance().DataTeX_Settings);
     currentBase.exec("SELECT db.Name FROM Current_Databases cd JOIN DataBases db ON cd.Value = db.FileName;");
     while(currentBase.next()){
         base = currentBase.value(0).toString();
@@ -34,13 +35,13 @@ Settings::Settings(QWidget *parent)
     }
     QStringList NotesFileNames;
     QStringList NotesNames;
-    QSqlQuery fields_2;//(DataTex::DataTeX_Settings);
+    QSqlQuery fields_2;//(SessionManager::instance().DataTeX_Settings);
     fields_2.exec("SELECT FileName,Name FROM DataBases");
     while(fields_2.next()){
         NotesFileNames.append(fields_2.value(0).toString());
         NotesNames.append(fields_2.value(1).toString());
     }
-    QSqlQuery currentNotesBase;//(DataTex::DataTeX_Settings);
+    QSqlQuery currentNotesBase;//(SessionManager::instance().DataTeX_Settings);
     currentNotesBase.exec("SELECT db.Name FROM Current_Databases cd JOIN DataBases db ON cd.Value = db.FileName;");
     while(currentNotesBase.next()){
         note=currentNotesBase.value(0).toString();
@@ -55,21 +56,21 @@ Settings::Settings(QWidget *parent)
         ui->ComboNote->setEnabled(false);
         ui->DeleteBase->setEnabled(false);
     }
-    currentbase_Exercises = DataTex::CurrentFilesDataBase.Database;
-    // QSqlQuery LoadPreambles(DataTex::DataTeX_Settings);
+    currentbase_Exercises = SessionManager::instance().CurrentFilesDataBase.Database;
+    // QSqlQuery LoadPreambles(SessionManager::instance().DataTeX_Settings);
     // LoadPreambles.exec("SELECT Id,Name FROM Preambles;");
     DTXSettings dtxsettings;
     QList<QStringList> preambleInfoList = dtxsettings.getCurrentPreambleInfo();
     for(QStringList list: preambleInfoList){
         ui->PreambleCombo->addItem(list[1],QVariant(list[0]));}
     QString CurrentPreamble;
-    QSqlQuery CurrentPreambleQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery CurrentPreambleQuery;//(SessionManager::instance().DataTeX_Settings);
     CurrentPreambleQuery.exec(QString("SELECT Name FROM Preambles WHERE Id = \"%1\";")
-                              .arg(DataTex::CurrentPreamble));
+                              .arg(SessionManager::instance().CurrentPreamble));
     while(CurrentPreambleQuery.next()){CurrentPreamble = CurrentPreambleQuery.value(0).toString();};
     ui->PreambleCombo->setCurrentText(CurrentPreamble);
-    ui->NotesPath->setText(DataTex::CurrentDocumentsDataBase.Path);
-    ui->DatabaseLineEdit->setText(DataTex::CurrentFilesDataBase.Path);
+    ui->NotesPath->setText(SessionManager::instance().CurrentDocumentsDataBase.Path);
+    ui->DatabaseLineEdit->setText(SessionManager::instance().CurrentFilesDataBase.Path);
 
     LoadTables(ui->ComboBaseList->currentData().toString());
     LoadDocTables(ui->ComboNote->currentData().toString());
@@ -98,13 +99,13 @@ Settings::Settings(QWidget *parent)
         emit selectEditorFont(font);
     });
 
-    ui->PdfLatexPath->setText(DataTex::PdfLatex_Command);
-    ui->LatexPath->setText(DataTex::Latex_Command);
-    ui->XelatexPath->setText(DataTex::XeLatex_Command);
-    ui->LualatexPath->setText(DataTex::LuaLatex_Command);
-    ui->PythontexPath->setText(DataTex::Pythontex_Command);
-    ui->BibtexPath->setText(DataTex::Bibtex_Command);
-    ui->AsymptotePath->setText(DataTex::Asymptote_Command);
+    ui->PdfLatexPath->setText(SessionManager::instance().PdfLatex_Command);
+    ui->LatexPath->setText(SessionManager::instance().Latex_Command);
+    ui->XelatexPath->setText(SessionManager::instance().XeLatex_Command);
+    ui->LualatexPath->setText(SessionManager::instance().LuaLatex_Command);
+    ui->PythontexPath->setText(SessionManager::instance().Pythontex_Command);
+    ui->BibtexPath->setText(SessionManager::instance().Bibtex_Command);
+    ui->AsymptotePath->setText(SessionManager::instance().Asymptote_Command);
 
     ui->DatabasePassword->setEnabled(false);
     ui->DocDatabasePassword->setEnabled(false);
@@ -128,7 +129,7 @@ Settings::Settings(QWidget *parent)
         ui->LanguageSelect->addItem(QIcon(":/languages/"+Lang+".png"),LangName,QVariant(Lang));
         qDebug()<<Lang;
     }
-//    ui->LanguageSelect->setCurrentIndex(ui->LanguageSelect->findData(DataTex::currentlanguage,Qt::UserRole,Qt::MatchExactly));
+//    ui->LanguageSelect->setCurrentIndex(ui->LanguageSelect->findData(SessionManager::instance().currentlanguage,Qt::UserRole,Qt::MatchExactly));
     QSettings settings;
     currentLanguage = settings.value("Application_Settings/Language").toString();
     ui->EditorFontSelect->setCurrentFont(settings.value("Application_Settings/EditorFont").toString());
@@ -152,7 +153,7 @@ Settings::Settings(QWidget *parent)
     ui->saveDDBPrefix->setEnabled(false);
     connect(ui->savePasswordFDB,&QPushButton::clicked,this,[&](){
         ui->EncryptDatabase->setChecked(false);
-        QSqlQuery fdb_encription;//(DataTex::DataTeX_Settings);
+        QSqlQuery fdb_encription;//(SessionManager::instance().DataTeX_Settings);
         QString Password = QCryptographicHash::hash(ui->DatabasePassword->text().toUtf8(),QCryptographicHash::Sha256);
         QString db = QFileInfo(ui->ComboBaseList->currentData().toString()).baseName();
         fdb_encription.exec(QString("UPDATE DataBases SET UserName = '%1' WHERE FileName = '%2'")
@@ -163,7 +164,7 @@ Settings::Settings(QWidget *parent)
     });
     connect(ui->savePasswordDDB,&QPushButton::clicked,this,[&](){
         ui->EncryptDocDatabase->setChecked(false);
-        QSqlQuery fdb_encription;//(DataTex::DataTeX_Settings);
+        QSqlQuery fdb_encription;//(SessionManager::instance().DataTeX_Settings);
         QString Password = QCryptographicHash::hash(ui->DocDatabasePassword->text().toUtf8(),QCryptographicHash::Sha256).data();
         QString db = QFileInfo(ui->ComboNote->currentData().toString()).baseName();
         fdb_encription.exec(QString("UPDATE DataBases SET UserName = '%1' WHERE FileName = '%2'")
@@ -174,7 +175,7 @@ Settings::Settings(QWidget *parent)
 
     connect(ui->saveFDBPrefix,&QPushButton::clicked,this,[&](){
         ui->UseDatabasePrefix->setChecked(false);
-        QSqlQuery fdb_prefix;//(DataTex::DataTeX_Settings);
+        QSqlQuery fdb_prefix;//(SessionManager::instance().DataTeX_Settings);
         QString db = QFileInfo(ui->ComboBaseList->currentData().toString()).baseName();
         fdb_prefix.exec(QString("UPDATE DataBases SET Prefix = '%1' WHERE FileName = '%2'")
                                 .arg(ui->DatabasePrefix->text(),db));
@@ -182,7 +183,7 @@ Settings::Settings(QWidget *parent)
     });
     connect(ui->savePasswordDDB,&QPushButton::clicked,this,[&](){
         ui->UseDocDatabasePrefix->setChecked(false);
-        QSqlQuery fdb_prefix;//(DataTex::DataTeX_Settings);
+        QSqlQuery fdb_prefix;//(SessionManager::instance().DataTeX_Settings);
         QString db = QFileInfo(ui->ComboNote->currentData().toString()).baseName();
         fdb_prefix.exec(QString("UPDATE DataBases SET Prefix = '%1' WHERE FileName = '%2'")
                             .arg(ui->DocDatabasePrefix->text(),db));
@@ -200,7 +201,7 @@ void Settings::LoadTables(QString database)
 {
     QSqlQueryModel * Metadata = new QSqlQueryModel(this);
 //    QSqlQueryModel * Bibliography = new QSqlQueryModel(this);
-    QSqlQuery tableQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery tableQuery;//(SessionManager::instance().DataTeX_Settings);
     tableQuery.prepare(QString("SELECT m.Id AS 'Field Id',m.Name AS 'Name' FROM Metadata_per_Database md JOIN Metadata m ON md.Metadata_Id = m.Id WHERE Database_FileName = \"%1\"")
                        .arg(database));
     tableQuery.exec();
@@ -217,7 +218,7 @@ void Settings::LoadTables(QString database)
 void Settings::LoadDocTables(QString database)
 {
     QSqlQueryModel * DocMetadata = new QSqlQueryModel(this);
-    QSqlQuery tableQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery tableQuery;//(SessionManager::instance().DataTeX_Settings);
     tableQuery.prepare(QString("SELECT m.Id AS 'Field Id',m.Name AS 'Name' FROM DocMetadata_per_Database md JOIN DocMetadata m ON md.Metadata_Id = m.Id WHERE Database_FileName = \"%1\"")
                        .arg(database));
     tableQuery.exec();
@@ -242,7 +243,7 @@ void Settings::on_BaseButton_clicked()
 void Settings::CreateBaseFolder(QString path,QString FolderName,QString fileName)
 {
     QString FullPath = path+QDir::separator()+FolderName+QDir::separator()+fileName+".db";
-    QSqlQuery AddBaseQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery AddBaseQuery;//(SessionManager::instance().DataTeX_Settings);
     AddBaseQuery.exec(QString("INSERT INTO Databases (FileName,Name,Path) VALUES (\"%1\",\"%2\",\"%3\")")
                        .arg(fileName,FolderName,FullPath));
     ui->DatabaseLineEdit->setText(FullPath);
@@ -265,15 +266,15 @@ void Settings::CreateNoteFolder(QString path,QString FolderName,QString FileName
 void Settings::on_buttonBox_accepted()
 {
     QString Text = ui->PreambleText->toPlainText();
-    QSqlQuery WritePreambleQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery WritePreambleQuery;//(SessionManager::instance().DataTeX_Settings);
     QString preamble = ui->PreambleCombo->currentData().toString();
-    QSqlQuery SaveData;//(DataTex::DataTeX_Settings);
+    QSqlQuery SaveData;//(SessionManager::instance().DataTeX_Settings);
     SaveData.exec(QString("UPDATE Initial_Settings SET Value = \"%1\" WHERE Setting = 'Current_Preamble'")
                   .arg(preamble));
     WritePreambleQuery.exec(QString("UPDATE Preambles SET Preamble_Content = \"%1\" "
                                     "WHERE Id = \"%2\";").arg(Text,ui->PreambleCombo->currentData().toString()));
 //    SelectLanguage(ui->LanguageSelect->currentData().toString());
-    QSqlQuery saveFont;//(DataTex::DataTeX_Settings);
+    QSqlQuery saveFont;//(SessionManager::instance().DataTeX_Settings);
     saveFont.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2'").arg(ui->EditorFontSelect->currentText(),"EditorFont"));
 
     QSettings settings;
@@ -338,19 +339,19 @@ void Settings::on_ComboBaseList_currentIndexChanged(int index)
         QString basename = ui->ComboBaseList->currentData().toString();
         QString path;
         LoadTables(basename);
-        QSqlQuery Path;//(DataTex::DataTeX_Settings);
+        QSqlQuery Path;//(SessionManager::instance().DataTeX_Settings);
         Path.exec(QString("SELECT Path From Databases WHERE FileName = \"%1\"").arg(basename));
         while(Path.next()){
             path = Path.value(0).toString();
         }
         ui->DatabaseLineEdit->setText(path);
 //        QString user = SqlFunctions::Get_String_From_Query(
-//            QString("SELECT UserName FROM DataBases WHERE FileName = '%1'").arg(basename),DataTex::DataTeX_Settings);
+//            QString("SELECT UserName FROM DataBases WHERE FileName = '%1'").arg(basename),SessionManager::instance().DataTeX_Settings);
 //        QString pass = SqlFunctions::Get_String_From_Query(
-//            QString("SELECT PassWord FROM DataBases WHERE FileName = '%1'").arg(basename),DataTex::DataTeX_Settings);
+//            QString("SELECT PassWord FROM DataBases WHERE FileName = '%1'").arg(basename),SessionManager::instance().DataTeX_Settings);
 //        ui->DatabaseUserName->setText(user);
 //        ui->DatabasePassword->setText(pass);
-        QString prefix;// = SqlFunctions::Get_String_From_Query(QString("SELECT Prefix FROM DataBases WHERE FileName = '%1'").arg(basename),DataTex::DataTeX_Settings);
+        QString prefix;// = SqlFunctions::Get_String_From_Query(QString("SELECT Prefix FROM DataBases WHERE FileName = '%1'").arg(basename),SessionManager::instance().DataTeX_Settings);
         ui->DatabasePrefix->setText(prefix);
     }
 }
@@ -369,7 +370,7 @@ void Settings::on_DeleteFilesBase_clicked()
     msgbox.setCheckBox(cb);
 
     if(msgbox.exec() == QMessageBox::Ok){
-        QSqlQuery DeleteQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery DeleteQuery;//(SessionManager::instance().DataTeX_Settings);
         DeleteQuery.exec("PRAGMA foreign_keys = ON");
         DeleteQuery.exec(QString("DELETE FROM Databases WHERE FileName = \"%1\"").arg(ui->ComboBaseList->currentData().toString()));
         if(ui->ComboBaseList->count()==1){
@@ -389,16 +390,16 @@ void Settings::on_ComboNote_currentIndexChanged(int index)
         QString notefolder = ui->ComboNote->currentData().toString();
         QString path;
         LoadDocTables(notefolder);
-        QSqlQuery Path;//(DataTex::DataTeX_Settings);
+        QSqlQuery Path;//(SessionManager::instance().DataTeX_Settings);
         Path.exec(QString("SELECT Path From DataBases WHERE FileName = \"%1\"").arg(notefolder));
         while(Path.next()){
             path = Path.value(0).toString();
         }
         ui->NotesPath->setText(path);
 //        QString user = SqlFunctions::Get_String_From_Query(
-//            QString("SELECT UserName FROM DataBases WHERE FileName = '%1'").arg(notefolder),DataTex::DataTeX_Settings);
+//            QString("SELECT UserName FROM DataBases WHERE FileName = '%1'").arg(notefolder),SessionManager::instance().DataTeX_Settings);
 //        QString pass = SqlFunctions::Get_String_From_Query(
-//            QString("SELECT PassWord FROM DataBases WHERE FileName = '%1'").arg(notefolder),DataTex::DataTeX_Settings);
+//            QString("SELECT PassWord FROM DataBases WHERE FileName = '%1'").arg(notefolder),SessionManager::instance().DataTeX_Settings);
 //        ui->DocDatabaseUserName->setText(user);
 //        ui->DocDatabasePassword->setText(pass);
     }
@@ -418,7 +419,7 @@ void Settings::on_DeleteBase_clicked()
     msgbox.setCheckBox(cb);
 
     if(msgbox.exec() == QMessageBox::Ok){
-        QSqlQuery DeleteQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery DeleteQuery;//(SessionManager::instance().DataTeX_Settings);
         DeleteQuery.exec("PRAGMA foreign_keys = ON");
         DeleteQuery.exec(QString("DELETE FROM DataBases WHERE FileName = \"%1\"").arg(ui->ComboNote->currentData().toString()));
         if(ui->ComboNote->count()==1){
@@ -438,7 +439,7 @@ void Settings::on_AddBase_clicked()
     QString DatabaseName = QFileInfo(Database).baseName();
     QStringList list = QFileInfo(Database).absolutePath().split(QDir::separator());
     QString folderName = list.last();
-    QSqlQuery AddNotesQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery AddNotesQuery;//(SessionManager::instance().DataTeX_Settings);
     AddNotesQuery.exec(QString("INSERT INTO Databases (FileName,Name,Path) VALUES (\"%1\",\"%2\",\"%3\")")
                        .arg(DatabaseName,folderName,Database));
 
@@ -451,7 +452,7 @@ void Settings::on_AddBase_clicked()
     QStringList MetadataNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE Table_Id = 'Metadata'",addeddatabaseFile);
     addeddatabaseFile.close();
 
-    QSqlQuery add;//(DataTex::DataTeX_Settings);
+    QSqlQuery add;//(SessionManager::instance().DataTeX_Settings);
     for (int i=0;i<MetadataIds.count();i++) {
         add.exec(QString("INSERT OR IGNORE INTO Metadata (Id,Name,Basic) VALUES (\""+MetadataIds.at(i)+"\",\""+MetadataNames.at(i)+"\",0)"));
         add.exec("INSERT OR IGNORE INTO Metadata_per_Database (Database_FileName,Metadata_Id) VALUES (\""+DatabaseName+"\",\""+MetadataIds.at(i)+"\")");
@@ -468,7 +469,7 @@ void Settings::on_PreambleCombo_currentIndexChanged(const QString &arg1)
     ui->RemovePreambleButton->setEnabled(ui->PreambleCombo->currentData().toString()!="Basic");
     QString Preambletext;
     ui->PreambleText->clear();
-    QSqlQuery PreambleQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery PreambleQuery;//(SessionManager::instance().DataTeX_Settings);
     PreambleQuery.exec(QString("SELECT Preamble_Content FROM Preambles WHERE Id = \"%1\";")
                        .arg(ui->PreambleCombo->currentData().toString()));
     while(PreambleQuery.next()){Preambletext = PreambleQuery.value(0).toString();}
@@ -485,7 +486,7 @@ void Settings::on_AddPreambleButton_clicked()
 
 void Settings::AddPreamble(QStringList preamble)
 {
-    QSqlQuery AddPreamble;//(DataTex::DataTeX_Settings);
+    QSqlQuery AddPreamble;//(SessionManager::instance().DataTeX_Settings);
     AddPreamble.exec(QString("INSERT OR IGNORE INTO Preambles (Id,Name,Preamble_Content) VALUES (\"%1\",\"%2\",\"%3\")")
                      .arg(preamble[1],preamble[0],preamble[2]));
     ui->PreambleCombo->addItem(preamble[0],QVariant(preamble[1]));
@@ -500,7 +501,7 @@ void Settings::on_RemovePreambleButton_clicked()
                  tr("Delete preamble"),tr("The preamble %1 will be deleted!\nDo you wish to proceed?")
                                     .arg(currentPreamble),QMessageBox::No | QMessageBox::Yes,QMessageBox::Yes);
     if (resBtn == QMessageBox::Yes) {
-        QSqlQuery RemovePreamble;//(DataTex::DataTeX_Settings);
+        QSqlQuery RemovePreamble;//(SessionManager::instance().DataTeX_Settings);
         RemovePreamble.exec(QString("DELETE FROM Preambles WHERE Id = \"%1\"").arg(ui->PreambleCombo->currentData().toString()));
         ui->PreambleCombo->removeItem(ui->PreambleCombo->currentIndex());
     }
@@ -561,7 +562,7 @@ void Settings::on_AddDocDatabaseButton_clicked()
     QString DatabaseName = QFileInfo(Database).baseName();
     QStringList list = QFileInfo(Database).absolutePath().split(QDir::separator());
     QString folderName = list.last();
-    QSqlQuery AddNotesQuery;//(DataTex::DataTeX_Settings);
+    QSqlQuery AddNotesQuery;//(SessionManager::instance().DataTeX_Settings);
     AddNotesQuery.exec(QString("INSERT INTO DataBases (FileName,Name,Path) VALUES (\"%1\",\"%2\",\"%3\")")
                        .arg(DatabaseName,folderName,Database));
 
@@ -574,7 +575,7 @@ void Settings::on_AddDocDatabaseButton_clicked()
     QStringList MetadataNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE Table_Id = 'Metadata'",addeddatabaseFile);
     addeddatabaseFile.close();
 
-    QSqlQuery add;//(DataTex::DataTeX_Settings);
+    QSqlQuery add;//(SessionManager::instance().DataTeX_Settings);
     for (int i=0;i<MetadataIds.count();i++) {
         add.exec(QString("INSERT OR IGNORE INTO DocMetadata (Id,Name,Basic) VALUES (\""+MetadataIds.at(i)+"\",\""+MetadataNames.at(i)+"\",0)"));
         add.exec("INSERT OR IGNORE INTO DocMetadata_per_Database (Database_FileName,Metadata_Id) VALUES (\""+DatabaseName+"\",\""+MetadataIds.at(i)+"\")");
@@ -616,26 +617,26 @@ void Settings::on_EncryptDatabase_toggled(bool checked)
 
 void Settings::on_OpenSaveLocation_clicked()
 {
-    QString path = QFileDialog::getExistingDirectory(this,tr("Select a save location"),DataTex::GlobalSaveLocation);
+    QString path = QFileDialog::getExistingDirectory(this,tr("Select a save location"),SessionManager::instance().GlobalSaveLocation);
     if(path.isEmpty())return;
-    DataTex::GlobalSaveLocation = path;
-    ui->SaveLocation->setText(DataTex::GlobalSaveLocation);
-    QSqlQuery query;//(DataTex::DataTeX_Settings);
+    SessionManager::instance().GlobalSaveLocation = path;
+    ui->SaveLocation->setText(SessionManager::instance().GlobalSaveLocation);
+    QSqlQuery query;//(SessionManager::instance().DataTeX_Settings);
     query.exec(QString("UPDATE Initial_Settings SET Value = \"%1\" WHERE Setting = 'SaveLocation'").arg(path));
 }
 
 void Settings::on_OpenPdfLatexPath_clicked()
 {
     QString pdflatex = QFileDialog::getOpenFileName(this,
-            tr("PdfLaTeX path"),DataTex::TexLivePath, "pdflatex");
+            tr("PdfLaTeX path"),SessionManager::instance().TexLivePath, "pdflatex");
     if(pdflatex.isEmpty()){
         return;
     }
     else{
-        DataTex::PdfLatex_Command = pdflatex;
-        DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX].Path = pdflatex;//CurrentBuildCommand
+        SessionManager::instance().PdfLatex_Command = pdflatex;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX].Path = pdflatex;//CurrentBuildCommand
         ui->PdfLatexPath->setText(pdflatex);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(pdflatex,"Pdflatex_Command"));
     }
 }
@@ -643,15 +644,15 @@ void Settings::on_OpenPdfLatexPath_clicked()
 void Settings::on_OpenLatexPath_clicked()
 {
     QString latex = QFileDialog::getOpenFileName(this,
-            tr("LaTeX path"),DataTex::TexLivePath, "latex");
+            tr("LaTeX path"),SessionManager::instance().TexLivePath, "latex");
     if(latex.isEmpty()){
         return;
     }
     else{
-        DataTex::Latex_Command = latex;
-        DataTex::DTXBuildCommands[(int)CompileEngine::LaTeX].Path = latex;
+        SessionManager::instance().Latex_Command = latex;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::LaTeX].Path = latex;
         ui->LatexPath->setText(latex);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(latex,"Latex_Command"));
     }
 }
@@ -659,15 +660,15 @@ void Settings::on_OpenLatexPath_clicked()
 void Settings::on_OpenXeLatexPath_clicked()
 {
     QString xelatex = QFileDialog::getOpenFileName(this,
-            tr("XeLaTeX path"),DataTex::TexLivePath, "xelatex");
+            tr("XeLaTeX path"),SessionManager::instance().TexLivePath, "xelatex");
     if(xelatex.isEmpty()){
         return;
     }
     else{
-        DataTex::XeLatex_Command = xelatex;
-        DataTex::DTXBuildCommands[(int)CompileEngine::XeLaTeX].Path = xelatex;
+        SessionManager::instance().XeLatex_Command = xelatex;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::XeLaTeX].Path = xelatex;
         ui->XelatexPath->setText(xelatex);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(xelatex,"Xelatex_Command"));
     }
 }
@@ -675,15 +676,15 @@ void Settings::on_OpenXeLatexPath_clicked()
 void Settings::on_OpenLuaLatexPath_clicked()
 {
     QString lualatex = QFileDialog::getOpenFileName(this,
-            tr("LuaLaTeX path"),DataTex::TexLivePath, "lualatex");
+            tr("LuaLaTeX path"),SessionManager::instance().TexLivePath, "lualatex");
     if(lualatex.isEmpty()){
         return;
     }
     else{
-        DataTex::LuaLatex_Command = lualatex;
-        DataTex::DTXBuildCommands[(int)CompileEngine::LuaLaTeX].Path = lualatex;
+        SessionManager::instance().LuaLatex_Command = lualatex;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::LuaLaTeX].Path = lualatex;
         ui->LualatexPath->setText(lualatex);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(lualatex,"Lualatex_Command"));
     }
 }
@@ -691,15 +692,15 @@ void Settings::on_OpenLuaLatexPath_clicked()
 void Settings::on_OpenPythontexPath_clicked()
 {
     QString pythontex = QFileDialog::getOpenFileName(this,
-            tr("PythonTeX path"),DataTex::TexLivePath, "pythontex");
+            tr("PythonTeX path"),SessionManager::instance().TexLivePath, "pythontex");
     if(pythontex.isEmpty()){
         return;
     }
     else{
-        DataTex::Pythontex_Command = pythontex;
-        DataTex::DTXBuildCommands[(int)CompileEngine::PythonTex].Path = pythontex;
+        SessionManager::instance().Pythontex_Command = pythontex;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PythonTex].Path = pythontex;
         ui->PythontexPath->setText(pythontex);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(pythontex,"Pythontex_Command"));
     }
 }
@@ -707,15 +708,15 @@ void Settings::on_OpenPythontexPath_clicked()
 void Settings::on_OpenBibtexPath_clicked()
 {
     QString bibtex = QFileDialog::getOpenFileName(this,
-            tr("BibTeX path"),DataTex::TexLivePath, "bibtex");
+            tr("BibTeX path"),SessionManager::instance().TexLivePath, "bibtex");
     if(bibtex.isEmpty()){
         return;
     }
     else{
-        DataTex::Bibtex_Command = bibtex;
-        DataTex::DTXBuildCommands[(int)CompileEngine::BibTeX].Path = bibtex;
+        SessionManager::instance().Bibtex_Command = bibtex;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::BibTeX].Path = bibtex;
         ui->BibtexPath->setText(bibtex);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(bibtex,"Bibtex_Command"));
     }
 }
@@ -723,27 +724,27 @@ void Settings::on_OpenBibtexPath_clicked()
 void Settings::on_OpenAsymptotePath_clicked()
 {
     QString asymptote = QFileDialog::getOpenFileName(this,
-            tr("Asymptote path"),DataTex::TexLivePath, "asymptote");
+            tr("Asymptote path"),SessionManager::instance().TexLivePath, "asymptote");
     if(asymptote.isEmpty()){
         return;
     }
     else{
-        DataTex::PdfLatex_Command = asymptote;
-        DataTex::DTXBuildCommands[(int)CompileEngine::Asymptote].Path = asymptote;
+        SessionManager::instance().PdfLatex_Command = asymptote;
+        SessionManager::instance().DTXBuildCommands[(int)CompileEngine::Asymptote].Path = asymptote;
         ui->AsymptotePath->setText(asymptote);
-        QSqlQuery CommandsQuery;//(DataTex::DataTeX_Settings);
+        QSqlQuery CommandsQuery;//(SessionManager::instance().DataTeX_Settings);
         CommandsQuery.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(asymptote,"Asymptote_Command"));
     }
 }
 
 void Settings::SelectLanguage(QString language)
 {
-    if (!DataTex::translator.isEmpty()){
-        QCoreApplication::removeTranslator(&DataTex::translator);
+    if (!SessionManager::instance().translator.isEmpty()){
+        QCoreApplication::removeTranslator(&SessionManager::instance().translator);
     }
-    DataTex::translator.load(":/languages/DataTex_"+language+".qm");
-    QCoreApplication::installTranslator(&DataTex::translator);
-    QSqlQuery saveLang;//(DataTex::DataTeX_Settings);
+    SessionManager::instance().translator.load(":/languages/DataTex_"+language+".qm");
+    QCoreApplication::installTranslator(&SessionManager::instance().translator);
+    QSqlQuery saveLang;//(SessionManager::instance().DataTeX_Settings);
     saveLang.exec(QString("UPDATE Initial_Settings SET Value = '%1' WHERE Setting = '%2';").arg(language,"Language"));
 }
 

--- a/datatex/solutionsdocument.cpp
+++ b/datatex/solutionsdocument.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "solutionsdocument.h"
 #include "ui_solutionsdocument.h"
 #include <QFileInfo>
@@ -37,7 +38,7 @@ SolutionsDocument::SolutionsDocument(QWidget *parent, QString fileName,
         QString exercise = order.value();
         QTreeWidgetItem * item = new QTreeWidgetItem();
         item->setText(0,exercise);
-        item->setText(2,DataTex::GlobalDatabaseList.value(QFileInfo(databasePerSolutionFile[exercise].databaseName()).baseName()).BaseName);
+        item->setText(2,SessionManager::instance().GlobalDatabaseList.value(QFileInfo(databasePerSolutionFile[exercise].databaseName()).baseName()).BaseName);
         ui->ExercisesInDocument->addTopLevelItem(item);
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
         item->setCheckState(0,Qt::Checked);
@@ -229,7 +230,7 @@ void SolutionsDocument::DocumentText()
 {
     QString FileContent;
     FileContent = "%# Document Id : "+QFileInfo(SolutionDocumentName).baseName()+"-----------------\n";
-    FileContent += "%@ DocumentsDB Id : "+DataTex::CurrentDocumentsDataBase.BaseName+"\n";
+    FileContent += "%@ DocumentsDB Id : "+SessionManager::instance().CurrentDocumentsDataBase.BaseName+"\n";
     FileContent += "%#--------------------------------------------------\n\n";
     for(int i=0;i<ui->ExercisesInDocument->topLevelItemCount();i++){
         QString Exercise = ui->ExercisesInDocument->topLevelItem(i)->text(0);
@@ -255,7 +256,7 @@ void SolutionsDocument::on_BuildButton_clicked()
     ui->SolutionsDocumentContent->toolBar->Save->trigger();
     FileCommands::CreateTexFile(SolutionDocumentName,0,"");
     qDebug()<<SolutionDocumentName;
-    FileCommands::BuildDocument(DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX],SolutionDocumentName);//CurrentBuildCommand
+    FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX],SolutionDocumentName);//CurrentBuildCommand
     FileCommands::ClearOldFiles(SolutionDocumentName);
     FileCommands::ShowPdfInViewer(SolutionDocumentName,SolutionsView);
 }
@@ -279,7 +280,7 @@ void SolutionsDocument::on_BuildButtonDoc_clicked()
 {
     ui->DocumentContent->toolBar->Save->trigger();
     FileCommands::CreateTexFile(DocumentName,0,"");
-    FileCommands::BuildDocument(DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX],DocumentName);//CurrentBuildCommand
+    FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX],DocumentName);//CurrentBuildCommand
     FileCommands::ClearOldFiles(DocumentName);
     FileCommands::ShowPdfInViewer(DocumentName,DocView);
 }

--- a/datatex/solvedatabaseexercise.cpp
+++ b/datatex/solvedatabaseexercise.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "solvedatabaseexercise.h"
 #include "ui_solvedatabaseexercise.h"
 #include <math.h>
@@ -8,7 +9,7 @@ SolveDatabaseExercise::SolveDatabaseExercise(QWidget *parent, QString fileName) 
     ui(new Ui::SolveDatabaseExercise)
 {
     ui->setupUi(this);
-    currentbase = DataTex::CurrentFilesDataBase.Database;
+    currentbase = SessionManager::instance().CurrentFilesDataBase.Database;
     ExerciseTable = new ExtendedTableWidget(this);
     ui->gridLayout->addWidget(ExerciseTable,1,0);
     ExerciseTable->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -85,8 +86,8 @@ SolveDatabaseExercise::SolveDatabaseExercise(QWidget *parent, QString fileName) 
         ui->SolutionNotReady->setChecked(!checked);
     });
 
-    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp WHERE Table_Id = 'Metadata'",DataTex::CurrentFilesDataBase.Database);
-    QStringList Database_HeaderNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE Table_Id = 'Metadata'",DataTex::CurrentFilesDataBase.Database);
+    Database_FileTableFields = SqlFunctions::Get_StringList_From_Query("SELECT Id FROM BackUp WHERE Table_Id = 'Metadata'",SessionManager::instance().CurrentFilesDataBase.Database);
+    QStringList Database_HeaderNames = SqlFunctions::Get_StringList_From_Query("SELECT Name FROM BackUp WHERE Table_Id = 'Metadata'",SessionManager::instance().CurrentFilesDataBase.Database);
     QSqlQueryModel * Model = new QSqlQueryModel(this);
     QSqlQuery tableQuery(currentbase);
 
@@ -105,7 +106,7 @@ SolveDatabaseExercise::SolveDatabaseExercise(QWidget *parent, QString fileName) 
     ExerciseTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     ExerciseTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     ExerciseTable->setAlternatingRowColors(true);
-    DataTex::LoadTableHeaders(ExerciseTable,Database_HeaderNames);
+    SessionManager::instance().LoadTableHeaders(ExerciseTable,Database_HeaderNames);
     ExerciseTable->setSelectionMode( QAbstractItemView::SingleSelection );
     int columns = ExerciseTable->model()->columnCount();
     ExerciseTable->generateFilters(columns,false);
@@ -113,7 +114,7 @@ SolveDatabaseExercise::SolveDatabaseExercise(QWidget *parent, QString fileName) 
             this, &SolveDatabaseExercise::ExerciseTable_SelectionChanged);
     connect(ExerciseTable->filterHeader(), &FilterTableHeader::filterValues, this, &SolveDatabaseExercise::updateFilter);
     if(!fileName.isEmpty()){
-        DataTex::SelectNewFileInModel(ExerciseTable,fileName);
+        SessionManager::instance().SelectNewFileInModel(ExerciseTable,fileName);
     }
     connect(ui->EnableSortingFiles,&QPushButton::toggled,this,[&](bool checked){
         filesSorting = checked;
@@ -161,10 +162,10 @@ SolveDatabaseExercise::~SolveDatabaseExercise()
 void SolveDatabaseExercise::updateFilter(QStringList values)
 {
     SqlFunctions::FilterTable(Database_FileTableFields,values,{"ft.Solvable > 0"});
-    DataTex::updateTableView(ExerciseTable,SqlFunctions::FilesTable_UpdateQuery,currentbase,this);
+    SessionManager::instance().updateTableView(ExerciseTable,SqlFunctions::FilesTable_UpdateQuery,currentbase,this);
     connect(ExerciseTable->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &SolveDatabaseExercise::ExerciseTable_SelectionChanged);
-//    DataTex::LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
+//    SessionManager::instance().LoadTableHeaders(FilesTable,Database_FileTableFieldNames);
 }
 
 void SolveDatabaseExercise::ExerciseTable_SelectionChanged()
@@ -174,7 +175,7 @@ void SolveDatabaseExercise::ExerciseTable_SelectionChanged()
         int row = ExerciseTable->currentIndex().row();
 //        QString FileType = ExerciseTable->model()->data(ExerciseTable->model()->index(row,ExerciseTable->model()->columnCount()-3)).toString();
         Exercise = ExerciseTable->model()->data(ExerciseTable->model()->index(row,7)).toString();
-        DataTex::CurrentPreamble = ExerciseTable->model()->data(ExerciseTable->model()->index(row,12)).toString();
+        SessionManager::instance().CurrentPreamble = ExerciseTable->model()->data(ExerciseTable->model()->index(row,12)).toString();
         CurrentBuildCommand = ExerciseTable->model()->data(ExerciseTable->model()->index(row,13)).toString();
 //        QString tempFile; = Exercise;
 //        tempFile.replace("-"+FileType,"-"+FileTypeSolIds[FileType]);
@@ -230,7 +231,7 @@ void SolveDatabaseExercise::CreateSolution()
         QSqlQuery solved(currentbase);
         solved.exec(QString("INSERT INTO Solutions_per_File (Solution_Id,Solution_Path,File_Id) VALUES ('%1', '%2','%3');").arg(solInfo->Id,solInfo->Path,ExerciseName));
         solved.exec(SqlFunctions::UpdateSolution.arg(ExerciseName));
-//        QSqlQuery writeExercise(DataTex::CurrentFilesDataBase.Database);
+//        QSqlQuery writeExercise(SessionManager::instance().CurrentFilesDataBase.Database);
 //        QStringList ColumnNames = SqlFunctions::Get_StringList_From_Query("SELECT \"name\" FROM pragma_table_info(\'Database_Files\');",currentbase);
 //        QStringList NewValues = ColumnNames;
 //        NewValues[0] = "\""+SolutionName+"\"";
@@ -273,7 +274,7 @@ void SolveDatabaseExercise::RebuildSolution()
     QString file = ui->SolutionsCombo->currentData().toString();
     ui->SolutionContent->toolBar->Save->trigger();
     FileCommands::CreateTexFile(file,0,"");
-    FileCommands::BuildDocument(DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX],file);//CurrentBuildCommand
+    FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX],file);//CurrentBuildCommand
     FileCommands::ClearOldFiles(file);
     FileCommands::ShowPdfInViewer(file,viewSolution);
 }
@@ -311,7 +312,7 @@ void SolveDatabaseExercise::on_DeleteCurrentSolution_clicked()
     msgbox.setDefaultButton(QMessageBox::Cancel);
     msgbox.setCheckBox(cb);
     if (msgbox.exec() == QMessageBox::Ok) {
-        QSqlQuery deleteQuery(DataTex::CurrentFilesDataBase.Database);
+        QSqlQuery deleteQuery(SessionManager::instance().CurrentFilesDataBase.Database);
         deleteQuery.exec("PRAGMA foreign_keys = ON");
         deleteQuery.exec(QString("DELETE FROM Database_Files WHERE Id = \"%1\"").arg(ui->SolutionsCombo->currentText()));
         deleteQuery.exec(SqlFunctions::UpdateSolution.arg(QFileInfo(Exercise).baseName()));
@@ -357,7 +358,7 @@ void SolveDatabaseExercise::RebuildExercise()
     QString file = exercise->editor->documentTitle();
     exercise->toolBar->Save->trigger();
     FileCommands::CreateTexFile(file,0,"");
-    FileCommands::BuildDocument(DataTex::DTXBuildCommands[(int)CompileEngine::PdfLaTeX],file);//CurrentBuildCommand
+    FileCommands::BuildDocument(SessionManager::instance().DTXBuildCommands[(int)CompileEngine::PdfLaTeX],file);//CurrentBuildCommand
     FileCommands::ClearOldFiles(file);
     FileCommands::ShowPdfInViewer(file,view);
 }

--- a/datatex/updatedocumentcontent.cpp
+++ b/datatex/updatedocumentcontent.cpp
@@ -1,3 +1,4 @@
+#include "sessionmanager.h"
 #include "updatedocumentcontent.h"
 #include "ui_updatedocumentcontent.h"
 #include <QTextStream>
@@ -39,11 +40,11 @@ UpdateDocumentContent::UpdateDocumentContent(QWidget *parent,QString Document,QS
 
     QString f = "(\""+fileNames.join("\",\"")+"\")";
     QSqlQueryModel * Files = new QSqlQueryModel(this);
-    QStringList datalist = {SqlFunctions::ShowFilesInADocument.arg(f,QFileInfo(DataTex::CurrentFilesDataBase.Path).baseName())};
+    QStringList datalist = {SqlFunctions::ShowFilesInADocument.arg(f,QFileInfo(SessionManager::instance().CurrentFilesDataBase.Path).baseName())};
     QString query;
-    QSqlQuery FilesQuery(DataTex::CurrentFilesDataBase.Database);
+    QSqlQuery FilesQuery(SessionManager::instance().CurrentFilesDataBase.Database);
     for (int i=0;i<databases.count();i++) {
-        if(databases.at(i)!=DataTex::CurrentFilesDataBase.Path) {
+        if(databases.at(i)!=SessionManager::instance().CurrentFilesDataBase.Path) {
             FilesQuery.exec(QString("ATTACH DATABASE \"%1\" AS \"%2\" ").arg(databases.at(i),QFileInfo(databases.at(i)).baseName()));
             datalist.append(SqlFunctions::ShowFilesInADocument_DifferentDatabase.arg(f,QFileInfo(databases.at(i)).baseName()));
         }
@@ -74,7 +75,7 @@ UpdateDocumentContent::~UpdateDocumentContent()
 {
     delete ui;
     for (int i=0;i<DatabasesInDocument.count();i++) {
-        if(DatabasesInDocument[i].databaseName()!=DataTex::CurrentFilesDataBase.Path){
+        if(DatabasesInDocument[i].databaseName()!=SessionManager::instance().CurrentFilesDataBase.Path){
             DatabasesInDocument[i].close();
         }
     }

--- a/sessionmanager.cpp
+++ b/sessionmanager.cpp
@@ -1,0 +1,147 @@
+#include "sessionmanager.h"
+#include <QSqlQuery>
+#include <QSqlRecord>
+#include <QSqlQueryModel>
+#include <QSortFilterProxyModel>
+#include <QHeaderView>
+#include <QDir>
+#include <QFileInfo>
+#include <QProcess>
+#include <QMessageBox>
+
+SessionManager& SessionManager::instance()
+{
+    static SessionManager instance;
+    return instance;
+}
+
+SessionManager::SessionManager()
+{
+    // Initialize databases or other members if necessary
+    DataTeX_Settings = QSqlDatabase::addDatabase("QSQLITE", "DataTexSettings");
+    Bibliography_Settings = QSqlDatabase::addDatabase("QSQLITE", "BibSettings");
+}
+
+SessionManager::~SessionManager()
+{
+}
+
+void SessionManager::updateTableView(QTableView * table,QString QueryText,QSqlDatabase Database,QObject * parent)
+{
+    if(table->model()) table->model()->deleteLater();
+    QSortFilterProxyModel *proxyModel = new QSortFilterProxyModel(table);
+    QSqlQueryModel * model = new QSqlQueryModel(proxyModel);
+    QSqlQuery query(Database);
+    query.exec(QueryText);
+    model->setQuery(query);
+    proxyModel->setSourceModel(model);
+    table->setModel(proxyModel);
+    table->show();
+    table->setSortingEnabled(true);
+}
+
+void SessionManager::LoadTableHeaders(QTableView * table,QStringList list)
+{
+    for (int i=0;i<list.count();i++) {
+        table->model()->setHeaderData(i,Qt::Horizontal,list.at(i),Qt::DisplayRole);
+    }
+}
+
+void SessionManager::StretchColumns(QTableView * Table, float stretchFactor)
+{
+    QFont myFont = Table->horizontalHeader()->font();
+    QFontMetrics fm(myFont);
+    for (int c = 0; c < Table->horizontalHeader()->count(); ++c)
+    {
+        QString str = Table->model()->headerData(c,Qt::Horizontal,Qt::DisplayRole).toString();
+        int width=fm.horizontalAdvance(str)*stretchFactor;
+        Table->setColumnWidth(c,width);
+    }
+    Table->horizontalHeader()->setMinimumSectionSize(100);
+}
+
+void SessionManager::StretchColumns(QTreeView * Tree, float stretchFactor)
+{
+    QFont myFont = Tree->header()->font();
+    QFontMetrics fm(myFont);
+    for (int c = 0; c < Tree->model()->columnCount(); ++c)
+    {
+        QString str = Tree->model()->headerData(c,Qt::Horizontal,Qt::DisplayRole).toString();
+        int width=fm.horizontalAdvance(str)*stretchFactor;
+        Tree->setColumnWidth(c,width);
+    }
+    Tree->header()->setMinimumSectionSize(100);
+}
+
+void SessionManager::StretchColumnsToWidth(QTableView * table)
+{
+    for (int c = 0; c < table->horizontalHeader()->count()-1; ++c)
+    {
+        table->horizontalHeader()->setSectionResizeMode(
+            c, QHeaderView::Stretch);
+    }
+}
+
+QStringList SessionManager::GetListWidgetItems(QListWidget * list)
+{
+    QStringList items;
+    for(int i=0;i<list->count();i++){
+        items.append(list->item(i)->text());
+    }
+    return items;
+}
+
+void SessionManager::DBBackUp(QString database, QString dest_path)
+{
+    QFile file(database);
+//    QProcess::execute("chmod",{"777",datatexpath});
+    if (QFile::exists(dest_path))
+    {
+        QFile::remove(dest_path);
+    }
+    file.copy(dest_path);
+//    QProcess::execute("chmod",{"555",datatexpath});
+}
+
+void SessionManager::runQuery_Root(QString queryText,QSqlDatabase database)
+{
+    /* Make dir writable for DataTex_Settings
+     * QProcess::execute("chmod",{"777",datatexpath});
+     * run query for DT and Bib databases
+     * QProcess::execute("chmod",{"555",datatexpath});
+     *  and back readable again */
+//    QProcess::execute("chmod",{"777",datatexpath});
+    QSqlQuery query(database);
+    query.exec(queryText);
+//    QProcess::execute("chmod",{"555",datatexpath});
+}
+
+QString SessionManager::getDataTexPath()
+{
+    return datatexpath;
+}
+
+bool SessionManager::SelectNewFileInModel(QTableView * table,QString newFile)
+{
+    QAbstractItemModel * m = table->model();
+    QModelIndex ix = table->currentIndex();
+    while (table->model()->canFetchMore(ix))
+           table->model()->fetchMore(ix);
+    QModelIndexList matchList = m->match(m->index(0,0), Qt::DisplayRole,
+                               newFile, -1,  Qt::MatchFlags(Qt::MatchContains|Qt::MatchWrap));
+
+    bool fileFound = matchList.count()>=1;
+    if(matchList.count()>=1){
+        table->setCurrentIndex(matchList.first());
+        table->scrollTo(matchList.first());
+    }
+    return fileFound;
+}
+
+void SessionManager::FunctionInProgress()
+{
+    QMessageBox msgBox;
+    msgBox.setText("This function will soon be completed.");
+    msgBox.addButton(QMessageBox::Ok);
+    msgBox.exec();
+}

--- a/sessionmanager.h
+++ b/sessionmanager.h
@@ -1,0 +1,80 @@
+#ifndef SESSIONMANAGER_H
+#define SESSIONMANAGER_H
+
+#include <QString>
+#include <QHash>
+#include <QStringList>
+#include <QTranslator>
+#include <QTableView>
+#include <QTreeView>
+#include <QListWidget>
+#include <QSqlDatabase>
+#include "databasecreator.h"
+#include "filecommands.h"
+
+class ExtendedTableWidget;
+
+class SessionManager
+{
+public:
+    static SessionManager& instance();
+
+    void updateTableView(QTableView * table, QString QueryText, QSqlDatabase Database, QObject *parent);
+    void LoadTableHeaders(QTableView * table, QStringList list);
+    void StretchColumns(QTableView * Table,float stretchFactor);
+    void StretchColumns(QTreeView * Tree,float stretchFactor);
+    void StretchColumnsToWidth(QTableView *table);
+    QStringList GetListWidgetItems(QListWidget * list);
+    void DBBackUp(QString database,QString dest_path);
+    void runQuery_Root(QString queryText, QSqlDatabase database);
+    QString getDataTexPath();
+    bool SelectNewFileInModel(QTableView *table, QString newFile);
+    void FunctionInProgress();
+
+    DTXDatabase CurrentFilesDataBase;
+    DTXDatabase CurrentDocumentsDataBase;
+    DTXDatabase CurrentBibliographyDataBase;
+    DTXDatabase CurrentTablesDataBase;
+    DTXDatabase CurrentFiguresDataBase;
+    DTXDatabase CurrentCommandsDataBase;
+    DTXDatabase CurrentPreamblesDataBase;
+    DTXDatabase CurrentPackagesDataBase;
+    DTXDatabase CurrentClassesDataBase;
+    DTXDatabase CurrentDTXDataBase;
+
+    QSqlDatabase DataTeX_Settings;
+    QSqlDatabase Bibliography_Settings;
+
+    QHash<QString,DTXDatabase> GlobalDatabaseList;
+
+    QString CurrentPreamble;
+    QString CurrentPreamble_Content;
+    QStringList DocTypesIds;
+    QStringList DocTypesNames;
+    QString PdfLatex_Command;
+    QString Latex_Command;
+    QString XeLatex_Command;
+    QString LuaLatex_Command;
+    QString Pythontex_Command;
+    QString Bibtex_Command;
+    QString Asymptote_Command;
+    QString RunCommand;
+    QHash<QString,QString> BuildCommands;
+    QHash<int,DTXBuildCommand> DTXBuildCommands;
+    QString GlobalSaveLocation;
+    QString TexLivePath;
+    QHash<QString,QStringList> Optional_DocMetadata_Ids;
+    QHash<QString,QStringList> Optional_DocMetadata_Names;
+    QTranslator translator;
+    QString currentlanguage;
+    QString datatexpath;
+    QStringList SVG_IconPaths;
+
+private:
+    SessionManager();
+    ~SessionManager();
+    SessionManager(const SessionManager&) = delete;
+    SessionManager& operator=(const SessionManager&) = delete;
+};
+
+#endif // SESSIONMANAGER_H


### PR DESCRIPTION
- Replaced static global members in `DataTex` with a `SessionManager` singleton to improve state management and code organization.
- Moved utility functions (`StretchColumns`, `updateTableView`, etc.) to `SessionManager`.
- Fixed memory leaks in `CreateCustomTagWidget` by properly deleting old widgets.
- Fixed a logic error and memory leak in `updateTableView` where the proxy model was unused and the old model was not deleted.
- Fixed a `QProcess` memory leak in the `DataTex` constructor.
- Initialized `DataTeX_Settings` and `Bibliography_Settings` databases in `SessionManager`.